### PR TITLE
ci: add check workflow for test, clippy, and fmt

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,84 @@
+name: Check
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/check.yml
+      - crates/**
+      - Cargo.*
+      - "!**/*.md"
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/check.yml
+      - crates/**
+      - Cargo.*
+      - "!**/*.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cargo-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Run cargo fmt
+        run: |
+          rustup component add rustfmt
+          cargo fmt \
+            --all \
+            --check
+
+  cargo-clippy:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Run cargo clippy
+        run: |
+          rustup component add clippy
+          cargo clippy \
+            --all-targets \
+            --all-features \
+            --locked \
+            -- \
+            -D warnings
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Run tests
+        run: >
+          cargo test
+          --all-targets
+          --all-features
+          --workspace
+          --locked


### PR DESCRIPTION
## Summary
- Add `check.yml` workflow for PR and main branch push
- Runs `cargo fmt --check`, `cargo clippy` (ubuntu + windows), and `cargo test` (ubuntu + macos + windows)
- Uses concurrency groups and path filters to avoid unnecessary runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)