### PR TITLE
style: fix fmt and clippy warnings

### DIFF
--- a/crates/rd-parser/src/lib.rs
+++ b/crates/rd-parser/src/lib.rs
@@ -37,7 +37,9 @@ mod lifecycle;
 mod roxygen;
 
 // Re-export main types for convenient access
-pub use ast::{DescribeItem, FigureOptions, RdDocument, RdNode, RdSection, SectionTag, SpecialChar};
+pub use ast::{
+    DescribeItem, FigureOptions, RdDocument, RdNode, RdSection, SectionTag, SpecialChar,
+};
 pub use lexer::{Lexer, Span, Token, TokenKind};
 pub use parser::{ParseError, ParseResult, Parser, parse};
 

--- a/crates/rd-parser/src/lifecycle.rs
+++ b/crates/rd-parser/src/lifecycle.rs
@@ -335,9 +335,7 @@ fn extract_lifecycle_from_filename(filename: &str) -> Option<Lifecycle> {
     // Remove "lifecycle-" prefix and file extension
     let stage_str = basename.strip_prefix("lifecycle-").and_then(|s| {
         // Split off the file extension if present
-        s.rsplit_once('.')
-            .map(|(name, _ext)| name)
-            .or(Some(s)) // No extension case
+        s.rsplit_once('.').map(|(name, _ext)| name).or(Some(s)) // No extension case
     })?;
 
     if stage_str.is_empty() {

--- a/crates/rd-parser/src/parser.rs
+++ b/crates/rd-parser/src/parser.rs
@@ -2,7 +2,9 @@
 //!
 //! Recursive descent parser that converts a token stream into an Rd AST.
 
-use crate::ast::{DescribeItem, FigureOptions, RdDocument, RdNode, RdSection, SectionTag, SpecialChar};
+use crate::ast::{
+    DescribeItem, FigureOptions, RdDocument, RdNode, RdSection, SectionTag, SpecialChar,
+};
 use crate::lexer::{Lexer, Token, TokenKind};
 use thiserror::Error;
 
@@ -1147,11 +1149,17 @@ test(x, y = TRUE)
     fn test_figure_expert_form() {
         // Form 3: \figure{filename}{options: string}
         // Note: "options:" prefix is stripped, remaining string is stored
-        let doc = parse(r#"\description{\figure{Rlogo.svg}{options: width=100 alt="R logo"}}"#).unwrap();
+        let doc =
+            parse(r#"\description{\figure{Rlogo.svg}{options: width=100 alt="R logo"}}"#).unwrap();
         let content = &doc.sections[0].content;
         if let RdNode::Figure { file, options } = &content[0] {
             assert_eq!(file, "Rlogo.svg");
-            assert_eq!(options, &Some(FigureOptions::ExpertOptions(r#"width=100 alt="R logo""#.to_string())));
+            assert_eq!(
+                options,
+                &Some(FigureOptions::ExpertOptions(
+                    r#"width=100 alt="R logo""#.to_string()
+                ))
+            );
         } else {
             panic!("Expected Figure node, got {:?}", content[0]);
         }
@@ -1161,11 +1169,19 @@ test(x, y = TRUE)
     fn test_figure_lifecycle_badge_style() {
         // Lifecycle badge format with single quotes
         // Note: "options:" prefix is stripped
-        let doc = parse(r#"\description{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}"#).unwrap();
+        let doc = parse(
+            r#"\description{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}"#,
+        )
+        .unwrap();
         let content = &doc.sections[0].content;
         if let RdNode::Figure { file, options } = &content[0] {
             assert_eq!(file, "lifecycle-deprecated.svg");
-            assert_eq!(options, &Some(FigureOptions::ExpertOptions("alt='[Deprecated]'".to_string())));
+            assert_eq!(
+                options,
+                &Some(FigureOptions::ExpertOptions(
+                    "alt='[Deprecated]'".to_string()
+                ))
+            );
         } else {
             panic!("Expected Figure node, got {:?}", content[0]);
         }
@@ -1192,7 +1208,10 @@ test(x, y = TRUE)
         let content = &doc.sections[0].content;
         if let RdNode::Figure { file, options } = &content[0] {
             assert_eq!(file, "file.png");
-            assert_eq!(options, &Some(FigureOptions::AltText("options are shown here".to_string())));
+            assert_eq!(
+                options,
+                &Some(FigureOptions::AltText("options are shown here".to_string()))
+            );
         } else {
             panic!("Expected Figure node, got {:?}", content[0]);
         }
@@ -1205,7 +1224,10 @@ test(x, y = TRUE)
         let content = &doc.sections[0].content;
         if let RdNode::Figure { file, options } = &content[0] {
             assert_eq!(file, "file.png");
-            assert_eq!(options, &Some(FigureOptions::AltText("options:nospace".to_string())));
+            assert_eq!(
+                options,
+                &Some(FigureOptions::AltText("options:nospace".to_string()))
+            );
         } else {
             panic!("Expected Figure node, got {:?}", content[0]);
         }
@@ -1218,7 +1240,12 @@ test(x, y = TRUE)
         // Form 1: \link{topic}
         let doc = parse(r#"\description{\link{foo}}"#).unwrap();
         let content = &doc.sections[0].content;
-        if let RdNode::Link { package, topic, text } = &content[0] {
+        if let RdNode::Link {
+            package,
+            topic,
+            text,
+        } = &content[0]
+        {
             assert_eq!(package, &None);
             assert_eq!(topic, "foo");
             assert_eq!(text, &None);
@@ -1232,7 +1259,12 @@ test(x, y = TRUE)
         // Form 2: \link[pkg]{topic}
         let doc = parse(r#"\description{\link[dplyr]{filter}}"#).unwrap();
         let content = &doc.sections[0].content;
-        if let RdNode::Link { package, topic, text } = &content[0] {
+        if let RdNode::Link {
+            package,
+            topic,
+            text,
+        } = &content[0]
+        {
             assert_eq!(package, &Some("dplyr".to_string()));
             assert_eq!(topic, "filter");
             assert_eq!(text, &None);
@@ -1246,7 +1278,12 @@ test(x, y = TRUE)
         // Form 3: \link[pkg:bar]{text} - topic comes from pkg:bar, brace content is display text
         let doc = parse(r#"\description{\link[rlang:abort]{abort function}}"#).unwrap();
         let content = &doc.sections[0].content;
-        if let RdNode::Link { package, topic, text } = &content[0] {
+        if let RdNode::Link {
+            package,
+            topic,
+            text,
+        } = &content[0]
+        {
             assert_eq!(package, &Some("rlang".to_string()));
             assert_eq!(topic, "abort");
             assert!(text.is_some());
@@ -1268,7 +1305,12 @@ test(x, y = TRUE)
         // Form 4: \link[=dest]{text} - link to dest, display text
         let doc = parse(r#"\description{\link[=as_polars_series]{as_polars_series()}}"#).unwrap();
         let content = &doc.sections[0].content;
-        if let RdNode::Link { package, topic, text } = &content[0] {
+        if let RdNode::Link {
+            package,
+            topic,
+            text,
+        } = &content[0]
+        {
             assert_eq!(package, &None);
             assert_eq!(topic, "as_polars_series");
             assert!(text.is_some());
@@ -1289,7 +1331,12 @@ test(x, y = TRUE)
         // Real-world case: \link[rlang:dyn-dots]{dynamic dots}
         let doc = parse(r#"\description{\link[rlang:dyn-dots]{dynamic dots}}"#).unwrap();
         let content = &doc.sections[0].content;
-        if let RdNode::Link { package, topic, text } = &content[0] {
+        if let RdNode::Link {
+            package,
+            topic,
+            text,
+        } = &content[0]
+        {
             assert_eq!(package, &Some("rlang".to_string()));
             assert_eq!(topic, "dyn-dots");
             assert!(text.is_some());

--- a/crates/rd-parser/src/roxygen.rs
+++ b/crates/rd-parser/src/roxygen.rs
@@ -193,7 +193,10 @@ mod tests {
     fn test_json_serialization() {
         let metadata = RoxygenMetadata {
             is_generated: true,
-            source_files: vec!["R/coord-map.R".to_string(), "R/coord-quickmap.R".to_string()],
+            source_files: vec![
+                "R/coord-map.R".to_string(),
+                "R/coord-quickmap.R".to_string(),
+            ],
         };
 
         let json = serde_json::to_string(&metadata).unwrap();

--- a/crates/rd2qmd-cli/examples/benchmark.rs
+++ b/crates/rd2qmd-cli/examples/benchmark.rs
@@ -195,7 +195,7 @@ fn run_single_benchmark(
         unresolved_link_url: Some("https://rdrr.io/r/base/{topic}.html".to_string()),
         external_package_urls: external_urls.cloned(),
         exec_dontrun: false,
-        exec_donttest: true, // pkgdown-compatible default
+        exec_donttest: true,     // pkgdown-compatible default
         include_internal: false, // skip internal topics by default
     };
 

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -11,8 +11,7 @@ use std::path::{Path, PathBuf};
 pub const CONFIG_FILE_NAME: &str = "_rd2qmd.toml";
 
 /// Schema URL for the configuration file
-pub const SCHEMA_URL: &str =
-    "https://raw.githubusercontent.com/eitsupi/rd2qmd/main/crates/rd2qmd-cli/schema/rd2qmd.schema.json";
+pub const SCHEMA_URL: &str = "https://raw.githubusercontent.com/eitsupi/rd2qmd/main/crates/rd2qmd-cli/schema/rd2qmd.schema.json";
 
 /// Root configuration structure
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -263,9 +263,10 @@ fn main() -> Result<()> {
     };
 
     // quarto_code_blocks: CLI > Config > auto (based on format)
-    let quarto_code_blocks = cli.quarto_code_blocks.or(config.code.quarto_code_blocks).unwrap_or(
-        matches!(format, OutputFormat::Qmd | OutputFormat::Rmd),
-    );
+    let quarto_code_blocks = cli
+        .quarto_code_blocks
+        .or(config.code.quarto_code_blocks)
+        .unwrap_or(matches!(format, OutputFormat::Qmd | OutputFormat::Rmd));
 
     // exec_dontrun: CLI > Config > false
     let exec_dontrun = if cli.exec_dontrun {
@@ -490,7 +491,9 @@ fn convert_directory(
     let FullConvertResult {
         conversion: result,
         fallbacks,
-    } = converter.convert().with_context(|| "Package conversion failed")?;
+    } = converter
+        .convert()
+        .with_context(|| "Package conversion failed")?;
 
     // Display fallback warnings
     if !quiet && !fallbacks.is_empty() {
@@ -523,7 +526,10 @@ fn convert_directory(
             result.failed_files.len()
         );
         if !result.skipped_internal.is_empty() {
-            summary.push_str(&format!(", {} skipped (internal)", result.skipped_internal.len()));
+            summary.push_str(&format!(
+                ", {} skipped (internal)",
+                result.skipped_internal.len()
+            ));
         }
         eprintln!("{}", summary);
     }
@@ -610,7 +616,6 @@ fn display_fallback_warnings(
     }
 }
 
-
 /// Run the index subcommand: generate topic index JSON to stdout
 fn run_index_command(args: &IndexArgs) -> Result<()> {
     if !args.input.is_dir() {
@@ -667,8 +672,12 @@ fn run_init_command(args: &InitArgs) -> Result<()> {
     let config = Config::sample();
     let config_content = config.to_toml_with_schema()?;
 
-    fs::write(&args.output, &config_content)
-        .with_context(|| format!("Failed to write configuration file: {}", args.output.display()))?;
+    fs::write(&args.output, &config_content).with_context(|| {
+        format!(
+            "Failed to write configuration file: {}",
+            args.output.display()
+        )
+    })?;
 
     eprintln!("Created configuration file: {}", args.output.display());
     Ok(())
@@ -984,7 +993,10 @@ mod tests {
     fn test_merge_arguments_format_no_config() {
         let cli = default_cli();
         let config = Config::default();
-        assert_eq!(merge_arguments_format(&cli, &config), ArgumentsFormat::GridTable);
+        assert_eq!(
+            merge_arguments_format(&cli, &config),
+            ArgumentsFormat::GridTable
+        );
     }
 
     #[test]
@@ -997,7 +1009,10 @@ mod tests {
             },
             ..Default::default()
         };
-        assert_eq!(merge_arguments_format(&cli, &config), ArgumentsFormat::PipeTable);
+        assert_eq!(
+            merge_arguments_format(&cli, &config),
+            ArgumentsFormat::PipeTable
+        );
     }
 
     #[test]
@@ -1012,7 +1027,10 @@ mod tests {
             ..Default::default()
         };
         // CLI is not default (Grid), so CLI wins
-        assert_eq!(merge_arguments_format(&cli, &config), ArgumentsFormat::PipeTable);
+        assert_eq!(
+            merge_arguments_format(&cli, &config),
+            ArgumentsFormat::PipeTable
+        );
     }
 
     #[test]
@@ -1073,6 +1091,9 @@ mod tests {
         };
         let opts = merge_external_link_options(&cli, &config).unwrap();
         // CLI lib_paths should override config
-        assert_eq!(opts.lib_paths, vec![std::path::PathBuf::from("/home/user/R")]);
+        assert_eq!(
+            opts.lib_paths,
+            vec![std::path::PathBuf::from("/home/user/R")]
+        );
     }
 }

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -2,11 +2,11 @@
 //!
 //! Converts an Rd document into an mdast tree for Markdown output.
 
+#[cfg(feature = "roxygen")]
+use crate::roxygen_code_block::try_match_roxygen_code_block;
 use rd_parser::{
     DescribeItem, FigureOptions, RdDocument, RdNode, RdSection, SectionTag, SpecialChar,
 };
-#[cfg(feature = "roxygen")]
-use crate::roxygen_code_block::try_match_roxygen_code_block;
 use rd2qmd_mdast::{
     Align, DefinitionDescription, DefinitionList, DefinitionTerm, Html, Image, Node, Root, Table,
     TableCell, TableRow,
@@ -794,8 +794,7 @@ impl Converter {
                             .as_ref()
                             .and_then(|map| map.get(pkg.as_str()))
                         {
-                            let url =
-                                format!("{}/{}.html", base_url.trim_end_matches('/'), topic);
+                            let url = format!("{}/{}.html", base_url.trim_end_matches('/'), topic);
                             Some(Node::link(url, vec![Node::inline_code(display)]))
                         } else {
                             // No URL found - just inline code
@@ -885,7 +884,10 @@ impl Converter {
                 }
             }
             // Use UTF-8 encoded text for Markdown/HTML output
-            RdNode::Enc { encoded, fallback: _ } => Some(Node::text(encoded.clone())),
+            RdNode::Enc {
+                encoded,
+                fallback: _,
+            } => Some(Node::text(encoded.clone())),
             RdNode::Email(email) => {
                 let mailto = format!("mailto:{}", email);
                 Some(Node::link(mailto, vec![Node::text(email.clone())]))
@@ -1146,17 +1148,17 @@ impl Converter {
                     }
                     result.push_str(generic);
                 }
-                RdNode::LinkS4Class {
-                    package,
-                    classname,
-                } => {
+                RdNode::LinkS4Class { package, classname } => {
                     if let Some(pkg) = package {
                         result.push_str(&format!("{}::{}", pkg, classname));
                     } else {
                         result.push_str(classname);
                     }
                 }
-                RdNode::Enc { encoded, fallback: _ } => {
+                RdNode::Enc {
+                    encoded,
+                    fallback: _,
+                } => {
                     result.push_str(encoded);
                 }
                 RdNode::Doi(id) => {

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 use rd_parser::parse;
 use rd2qmd_mdast::mdast_to_qmd;
@@ -1391,7 +1390,10 @@ fn test_extract_alt_from_attrs_single_quotes() {
 fn test_extract_alt_from_attrs_no_alt() {
     // Expert form without alt attribute - should return None (caller uses filename)
     assert_eq!(Converter::extract_alt_from_attrs("width=100"), None);
-    assert_eq!(Converter::extract_alt_from_attrs("width=50 height=30"), None);
+    assert_eq!(
+        Converter::extract_alt_from_attrs("width=50 height=30"),
+        None
+    );
 }
 
 #[test]

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -439,7 +439,10 @@ impl RdConverter {
 /// assert!(qmd.contains("title:"));
 /// assert!(qmd.contains("Hello World"));
 /// ```
-pub fn convert_rd_content(content: &str, options: &RdConvertOptions) -> Result<String, ConvertError> {
+pub fn convert_rd_content(
+    content: &str,
+    options: &RdConvertOptions,
+) -> Result<String, ConvertError> {
     let doc = parse(content).map_err(|e| ConvertError::Parse(e.to_string()))?;
 
     // Build converter options

--- a/crates/rd2qmd-mdast/src/writer.rs
+++ b/crates/rd2qmd-mdast/src/writer.rs
@@ -97,8 +97,10 @@ impl<'a> Writer<'a> {
             self.output.push('\n');
         }
         if let Some(pagetitle) = &fm.pagetitle {
-            self.output
-                .push_str(&format!(r#"pagetitle: "{}""#, escape_yaml_string(pagetitle)));
+            self.output.push_str(&format!(
+                r#"pagetitle: "{}""#,
+                escape_yaml_string(pagetitle)
+            ));
             self.output.push('\n');
         }
         if let Some(format) = &fm.format {
@@ -108,8 +110,7 @@ impl<'a> Writer<'a> {
         // TODO: Add configuration to control which metadata fields are output
         if let Some(metadata) = &fm.metadata {
             if let Some(lifecycle) = &metadata.lifecycle {
-                self.output
-                    .push_str(&format!("lifecycle: {}\n", lifecycle));
+                self.output.push_str(&format!("lifecycle: {}\n", lifecycle));
             }
             if !metadata.aliases.is_empty() {
                 self.output.push_str("aliases:\n");
@@ -278,7 +279,7 @@ impl<'a> Writer<'a> {
 
         // Determine fence length: must be longer than any backtick sequence in content
         let fence_len = calculate_fence_length(&c.value);
-        let fence: String = std::iter::repeat('`').take(fence_len).collect();
+        let fence = "`".repeat(fence_len);
 
         self.output.push_str(&fence);
         if let Some(lang) = &c.lang {
@@ -1122,7 +1123,10 @@ mod tests {
                     aliases: vec![],
                     keywords: vec![],
                     concepts: vec![],
-                    source_files: vec!["R/coord-map.R".to_string(), "R/coord-quickmap.R".to_string()],
+                    source_files: vec![
+                        "R/coord-map.R".to_string(),
+                        "R/coord-quickmap.R".to_string(),
+                    ],
                 }),
             }),
             ..Default::default()

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -33,7 +33,7 @@ pub enum FallbackReason {
 
 use rayon::prelude::*;
 use rd2qmd_core::{
-    RdToMdastOptions, Frontmatter, RdMetadata, SectionTag, WriterOptions, extract_rd_metadata,
+    Frontmatter, RdMetadata, RdToMdastOptions, SectionTag, WriterOptions, extract_rd_metadata,
     extract_text, mdast_to_qmd, parse, parse_roxygen_comments, rd_to_mdast_with_options,
 };
 use serde::Serialize;
@@ -255,7 +255,9 @@ pub fn generate_topic_index(
         match extract_topic_info(file, &options.output_extension) {
             Ok(info) => {
                 // Skip internal topics unless include_internal is set
-                if !options.include_internal && info.metadata.keywords.contains(&"internal".to_string()) {
+                if !options.include_internal
+                    && info.metadata.keywords.contains(&"internal".to_string())
+                {
                     continue;
                 }
                 topics.push(info);
@@ -396,8 +398,7 @@ fn convert_single_file(
 ) -> ConvertOutcome {
     let convert = || -> std::result::Result<PathBuf, ConvertError> {
         // Read input file
-        let content =
-            fs::read_to_string(input).map_err(|e| ConvertError::Failed(e.to_string()))?;
+        let content = fs::read_to_string(input).map_err(|e| ConvertError::Failed(e.to_string()))?;
 
         // Parse Rd
         let doc =
@@ -806,7 +807,12 @@ An old deprecated function.
         assert_eq!(old_topic.file, "old_func.qmd");
         assert_eq!(old_topic.title, "Old Function");
         assert!(old_topic.metadata.aliases.contains(&"old_func".to_string()));
-        assert!(old_topic.metadata.aliases.contains(&"legacy_func".to_string()));
+        assert!(
+            old_topic
+                .metadata
+                .aliases
+                .contains(&"legacy_func".to_string())
+        );
         assert_eq!(old_topic.metadata.lifecycle, Some("deprecated".to_string()));
 
         // Both are hand-written, so no source_files
@@ -1116,7 +1122,9 @@ x <- 1
 
         let content = fs::read_to_string(out_dir.path().join("caller.qmd")).unwrap();
         // Link text has backticks
-        assert!(content.contains("[`unknown_external`](https://rdrr.io/r/base/unknown_external.html)"));
+        assert!(
+            content.contains("[`unknown_external`](https://rdrr.io/r/base/unknown_external.html)")
+        );
     }
 
     #[test]
@@ -1161,8 +1169,15 @@ x <- 1
 
         let content = fs::read_to_string(out_dir.path().join("tidyverse_user.qmd")).unwrap();
         // Link text uses [`package::topic`] format
-        assert!(content.contains("[`dplyr::mutate`](https://dplyr.tidyverse.org/reference/mutate.html)"));
-        assert!(content.contains("[`ggplot2::ggplot`](https://ggplot2.tidyverse.org/reference/ggplot.html)"));
+        assert!(
+            content
+                .contains("[`dplyr::mutate`](https://dplyr.tidyverse.org/reference/mutate.html)")
+        );
+        assert!(
+            content.contains(
+                "[`ggplot2::ggplot`](https://ggplot2.tidyverse.org/reference/ggplot.html)"
+            )
+        );
     }
 
     #[test]
@@ -1285,9 +1300,11 @@ x <- 1
         assert!(!out_dir.path().join("internal_func.qmd").exists());
 
         // Check skipped file name
-        assert!(result.conversion.skipped_internal[0]
-            .to_string_lossy()
-            .contains("internal_func.Rd"));
+        assert!(
+            result.conversion.skipped_internal[0]
+                .to_string_lossy()
+                .contains("internal_func.Rd")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Run `cargo fmt --all` to fix formatting across all crates
- Fix clippy `manual_str_repeat` warning in `rd2qmd-mdast/src/writer.rs` by replacing `std::iter::repeat('`').take(n).collect()` with `"`".repeat(n)`

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` passes
- [x] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)