### PR TITLE
chore: set MSRV to 1.88.0 and add CI check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,6 +72,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
         with:
           crate: cargo-msrv
@@ -79,10 +81,10 @@ jobs:
       - name: Run cargo msrv
         run: |
           # Verify MSRV for each package
-          find crates -mindepth 2 -name Cargo.toml | while read -r dir
+          find crates -mindepth 2 -name Cargo.toml | while read -r manifest
           do
-            echo "Checking package $dir"
-            cargo msrv verify --manifest-path "$dir" || exit 1
+            echo "Checking package $manifest"
+            cargo msrv verify --manifest-path "$manifest" || exit 1
           done
 
   test:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,6 +62,29 @@ jobs:
             -- \
             -D warnings
 
+  cargo-msrv:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-msrv
+          version: 0.19.3
+      - name: Run cargo msrv
+        run: |
+          # Verify MSRV for each package
+          find crates -mindepth 2 -name Cargo.toml | while read -r dir
+          do
+            echo "Checking package $dir"
+            cargo msrv verify --manifest-path "$dir" || exit 1
+          done
+
   test:
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ default-members = ["crates/rd2qmd-cli"]
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88.0"
 license = "MIT"
 repository = "https://github.com/eitsupi/rd2qmd"
 

--- a/crates/rd-parser/Cargo.toml
+++ b/crates/rd-parser/Cargo.toml
@@ -3,6 +3,7 @@ name = "rd-parser"
 description = "Parser for R Documentation (Rd) files"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [features]

--- a/crates/rd2qmd-cli/Cargo.toml
+++ b/crates/rd2qmd-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "rd2qmd"
 description = "CLI tool to convert Rd files to Quarto Markdown"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/crates/rd2qmd-core/Cargo.toml
+++ b/crates/rd2qmd-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "rd2qmd-core"
 description = "Core library for converting Rd files to Quarto Markdown"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [features]

--- a/crates/rd2qmd-mdast/Cargo.toml
+++ b/crates/rd2qmd-mdast/Cargo.toml
@@ -3,6 +3,7 @@ name = "rd2qmd-mdast"
 description = "mdast types and Quarto Markdown writer for rd2qmd"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [dependencies]

--- a/crates/rd2qmd-package/Cargo.toml
+++ b/crates/rd2qmd-package/Cargo.toml
@@ -3,6 +3,7 @@ name = "rd2qmd-package"
 description = "Package-level operations for converting R documentation to Quarto Markdown"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 


### PR DESCRIPTION
## Summary
- Set `rust-version = "1.88.0"` in workspace `Cargo.toml` and inherit in all crates
- Add `cargo-msrv verify` job to `check.yml` (ubuntu + windows)

## Test plan
- [x] `cargo-msrv` job passes on CI for all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)