### PR TITLE
chore: add crates.io metadata for all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
 repository = "https://github.com/eitsupi/rd2qmd"
+homepage = "https://github.com/eitsupi/rd2qmd"
+readme = "README.md"
+keywords = ["r", "rd", "quarto", "markdown", "documentation"]
 
 [workspace.dependencies]
 # Core dependencies

--- a/crates/rd-parser/Cargo.toml
+++ b/crates/rd-parser/Cargo.toml
@@ -5,6 +5,11 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories = ["parser-implementations"]
 
 [features]
 default = []

--- a/crates/rd2qmd-cli/Cargo.toml
+++ b/crates/rd2qmd-cli/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories = ["command-line-utilities"]
 
 [[bin]]
 name = "rd2qmd"

--- a/crates/rd2qmd-core/Cargo.toml
+++ b/crates/rd2qmd-core/Cargo.toml
@@ -5,6 +5,11 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories = ["text-processing"]
 
 [features]
 default = []

--- a/crates/rd2qmd-mdast/Cargo.toml
+++ b/crates/rd2qmd-mdast/Cargo.toml
@@ -5,6 +5,11 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories = ["text-processing"]
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/rd2qmd-package/Cargo.toml
+++ b/crates/rd2qmd-package/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories = ["text-processing"]
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- Add `homepage`, `readme`, `keywords` to workspace package metadata
- Add `repository`, `homepage`, `keywords`, `categories` to all crates (inherited from workspace where possible)
- Crates with their own README (`rd-parser`, `rd2qmd-mdast`) use local `readme = "README.md"`; others inherit root README via workspace

## Test plan
- [x] `cargo check` passes
- [x] Verify metadata with `cargo package --list` for each crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)