### PR TITLE
docs(readme): update installation section with crates.io and GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,27 @@ A fast Rd-to-Quarto Markdown converter written in Rust, with intelligent link re
 
 ## Installation
 
-### From source
+### Cargo
 
-```bash
-cargo install --git https://github.com/eitsupi/rd2qmd
+```sh
+cargo install rd2qmd
 ```
 
-### Build locally
+### GitHub Releases
 
-```bash
-git clone https://github.com/eitsupi/rd2qmd
-cd rd2qmd
-cargo build --release
+Pre-built binaries for Linux, macOS, and Windows are available on the [Releases](https://github.com/eitsupi/rd2qmd/releases) page. You can also use the installer scripts:
+
+macOS / Linux:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/eitsupi/rd2qmd/releases/latest/download/rd2qmd-installer.sh | sh
 ```
 
-The binary will be available at `target/release/rd2qmd`.
+Windows (PowerShell):
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/eitsupi/rd2qmd/releases/latest/download/rd2qmd-installer.ps1 | iex"
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A fast Rd-to-Quarto Markdown converter written in Rust, with intelligent link re
 ### Cargo
 
 ```sh
-cargo install rd2qmd
+cargo install --locked rd2qmd
 ```
 
 ### GitHub Releases


### PR DESCRIPTION
## Summary
- Replace "From source" (`cargo install --git`) with "Cargo" (`cargo install rd2qmd`) now that 0.1.0 is published on crates.io
- Add "GitHub Releases" section with pre-built binary links and installer scripts for macOS/Linux/Windows
- Remove "Build locally" section

## Test plan
- [x] Verify installer script URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)