### PR TITLE
ci: add trusted publishing workflow for crates.io

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,24 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - '**[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+      - run: cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated crates.io publishing via trusted publishing
- Triggered on version tag push, uses `cargo publish --workspace` to publish all workspace crates in dependency order
- Requires `crates-io` environment and trusted publishing configuration on crates.io for each crate

## Setup required
- [x] Create `crates-io` environment in GitHub repository settings
- [x] Configure trusted publishing on crates.io for each crate (rd2qmd-mdast, rd-parser, rd2qmd-core, rd2qmd-package, rd2qmd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)