### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    commit-message:
+      prefix: "ci: "
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    commit-message:
+      prefix: "chore: "
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated dependency updates
- Covers `cargo` and `github-actions` ecosystems with weekly schedule
- Sets 7-day cooldown to mitigate supply chain attack risk

## Test plan
- [ ] Verify Dependabot picks up the config and creates PRs on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)