### PR TITLE
ci: fix swap Dependabot commit-message prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: cargo
     directory: /
     commit-message:
-      prefix: "ci: "
+      prefix: "chore: "
     schedule:
       interval: weekly
     cooldown:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     commit-message:
-      prefix: "chore: "
+      prefix: "ci: "
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## Summary
- Swap `commit-message.prefix` between cargo (`"chore: "`) and github-actions (`"ci: "`) to match project conventions

## Test plan
- [ ] Verify future Dependabot PRs use the correct prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)