### PR TITLE
docs(rd2qmd-core,rd2qmd-package): add package-level READMEs and improve API docs

### DIFF
--- a/crates/rd2qmd-core/Cargo.toml
+++ b/crates/rd2qmd-core/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories = ["text-processing"]
 

--- a/crates/rd2qmd-core/README.md
+++ b/crates/rd2qmd-core/README.md
@@ -1,0 +1,73 @@
+# rd2qmd-core
+
+Core library for converting Rd files to Quarto Markdown.
+
+## Overview
+
+`rd2qmd-core` provides a complete pipeline for converting individual R documentation (Rd) files to Quarto Markdown (QMD). It handles Rd parsing, AST transformation, and Markdown output generation.
+
+This crate is designed to be used as a library by higher-level tools (CLI, R package, etc.).
+
+## API Levels
+
+This crate offers three levels of API for different use cases:
+
+### High-level: `RdConverter` builder (recommended)
+
+Fluent builder API for converting Rd content to Quarto Markdown in one step.
+
+```rust
+use rd2qmd_core::RdConverter;
+
+let qmd = RdConverter::new(r#"\name{foo}\title{Foo}\description{A function.}"#)
+    .frontmatter(true)
+    .pagetitle(true)
+    .quarto_code_blocks(true)
+    .convert()
+    .unwrap();
+```
+
+### Mid-level: `convert_rd_content` function
+
+Function-style API when you have a pre-configured `RdConvertOptions` struct. Useful when options are loaded from configuration files.
+
+```rust
+use rd2qmd_core::{convert_rd_content, RdConvertOptions};
+
+let options = RdConvertOptions::default();
+let qmd = convert_rd_content(
+    r#"\name{foo}\title{Foo}\description{A function.}"#,
+    &options,
+).unwrap();
+```
+
+### Low-level: `rd_to_mdast` / `rd_to_mdast_with_options`
+
+For advanced use cases requiring direct access to the mdast intermediate representation.
+Use this when you need to manipulate the AST before rendering, or integrate with
+other Markdown processing pipelines.
+
+```rust
+use rd2qmd_core::{parse, rd_to_mdast, mdast_to_qmd, WriterOptions};
+
+let doc = parse(r#"\name{foo}\title{Foo}\description{A function.}"#).unwrap();
+let mdast = rd_to_mdast(&doc);
+// ... manipulate mdast if needed ...
+let qmd = mdast_to_qmd(&mdast, &WriterOptions::default());
+```
+
+## Features
+
+- `lifecycle` - Enable lifecycle stage extraction from Rd documents
+- `roxygen` - Enable source file extraction from roxygen2 comments and roxygen2 markdown code block handling
+
+## Dependencies
+
+This crate builds on:
+
+- [`rd-parser`](https://crates.io/crates/rd-parser) - Rd file parsing
+- [`mdast-rd2qmd`](https://crates.io/crates/mdast-rd2qmd) - mdast types and Quarto Markdown writer
+
+## License
+
+MIT

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -1,6 +1,6 @@
 //! Rd AST to mdast conversion
 //!
-//! This module provides the mid-level conversion API that transforms a parsed
+//! This module provides the low-level conversion API that transforms a parsed
 //! [`RdDocument`] into an mdast ([`Root`]) tree for Markdown output.
 //!
 //! The main entry points are:

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -1,6 +1,15 @@
 //! Rd AST to mdast conversion
 //!
-//! Converts an Rd document into an mdast tree for Markdown output.
+//! This module provides the mid-level conversion API that transforms a parsed
+//! [`RdDocument`] into an mdast ([`Root`]) tree for Markdown output.
+//!
+//! The main entry points are:
+//! - [`rd_to_mdast`] - Convert with default options
+//! - [`rd_to_mdast_with_options`] - Convert with custom [`RdToMdastOptions`]
+//!
+//! This module handles conversion of all Rd section types (description, usage,
+//! arguments, value, details, examples, etc.) and inline markup (links, code,
+//! emphasis, math, lists, tables) into their mdast equivalents.
 
 #[cfg(feature = "roxygen")]
 use crate::roxygen_code_block::try_match_roxygen_code_block;
@@ -76,12 +85,25 @@ impl Default for RdToMdastOptions {
     }
 }
 
-/// Convert an Rd document to mdast
+/// Convert an Rd document to mdast with default options
+///
+/// This is a convenience wrapper around [`rd_to_mdast_with_options`] using
+/// [`RdToMdastOptions::default()`]. Internal links will be rendered as
+/// inline code since no alias map or link extension is configured.
+///
+/// For link resolution and other customizations, use
+/// [`rd_to_mdast_with_options`] instead.
 pub fn rd_to_mdast(doc: &RdDocument) -> Root {
     rd_to_mdast_with_options(doc, &RdToMdastOptions::default())
 }
 
-/// Convert an Rd document to mdast with options
+/// Convert an Rd document to mdast with custom options
+///
+/// Transforms a parsed [`RdDocument`] into an mdast [`Root`] tree. The resulting
+/// tree can be rendered to Quarto Markdown using [`mdast_to_qmd`](crate::mdast_to_qmd).
+///
+/// Use [`RdToMdastOptions`] to control link resolution, code block behavior,
+/// and table formatting.
 pub fn rd_to_mdast_with_options(doc: &RdDocument, options: &RdToMdastOptions) -> Root {
     let mut converter = Converter::new(options.clone());
     converter.convert_document(doc)

--- a/crates/rd2qmd-package/Cargo.toml
+++ b/crates/rd2qmd-package/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-readme.workspace = true
+readme = "README.md"
 keywords.workspace = true
 categories = ["text-processing"]
 

--- a/crates/rd2qmd-package/README.md
+++ b/crates/rd2qmd-package/README.md
@@ -1,0 +1,75 @@
+# rd2qmd-package
+
+Package-level operations for converting R documentation to Quarto Markdown.
+
+## Overview
+
+`rd2qmd-package` provides batch conversion of entire R packages (directories of Rd files) to Quarto Markdown. It handles alias index building for correct internal link resolution and supports parallel processing.
+
+This crate is designed to be used as a library by various interfaces (CLI, R package, etc.).
+
+## Key Types
+
+- **`RdPackage`** - Represents an R package's documentation directory. Scans for `.Rd` files and builds an alias index for link resolution.
+- **`PackageConverter`** - Builder for converting an entire package with configurable options.
+- **`TopicIndex`** / **`generate_topic_index`** - Generates a JSON index of all topics with metadata (name, title, aliases, lifecycle stage).
+
+## Usage
+
+### Basic conversion
+
+```rust,ignore
+use rd2qmd_package::{RdPackage, PackageConvertOptions, PackageConverter};
+use std::path::{Path, PathBuf};
+
+let package = RdPackage::from_directory(Path::new("man"), false)?;
+let options = PackageConvertOptions {
+    output_dir: PathBuf::from("docs/reference"),
+    output_extension: "qmd".to_string(),
+    ..Default::default()
+};
+
+let result = PackageConverter::new(&package, options).convert()?;
+println!("Converted {} files", result.conversion.success_count);
+```
+
+### Topic index generation
+
+```rust,ignore
+use rd2qmd_package::{RdPackage, TopicIndexOptions, generate_topic_index};
+use std::path::Path;
+
+let package = RdPackage::from_directory(Path::new("man"), false)?;
+let options = TopicIndexOptions {
+    output_extension: "qmd".to_string(),
+    ..Default::default()
+};
+let index = generate_topic_index(&package, &options)?;
+println!("{}", index.to_json()?);
+```
+
+### External link resolution (requires `external-links` feature)
+
+```rust,ignore
+use rd2qmd_package::{ExternalLinkOptions, PackageConverter};
+use std::path::PathBuf;
+
+let result = PackageConverter::new(&package, options)
+    .with_external_links(ExternalLinkOptions {
+        lib_paths: vec![PathBuf::from("/usr/local/lib/R/site-library")],
+        ..Default::default()
+    })
+    .convert()?;
+
+for (pkg, reason) in &result.fallbacks {
+    println!("Warning: {} used fallback URL ({:?})", pkg, reason);
+}
+```
+
+## Features
+
+- `external-links` - Enable external package link resolution. Resolves cross-package `\link[pkg]{topic}` references using installed package metadata and pkgdown URL conventions.
+
+## License
+
+MIT

--- a/crates/rd2qmd-package/README.md
+++ b/crates/rd2qmd-package/README.md
@@ -18,7 +18,7 @@ This crate is designed to be used as a library by various interfaces (CLI, R pac
 
 ### Basic conversion
 
-```rust,ignore
+```rust
 use rd2qmd_package::{RdPackage, PackageConvertOptions, PackageConverter};
 use std::path::{Path, PathBuf};
 
@@ -35,7 +35,7 @@ println!("Converted {} files", result.conversion.success_count);
 
 ### Topic index generation
 
-```rust,ignore
+```rust
 use rd2qmd_package::{RdPackage, TopicIndexOptions, generate_topic_index};
 use std::path::Path;
 
@@ -50,9 +50,18 @@ println!("{}", index.to_json()?);
 
 ### External link resolution (requires `external-links` feature)
 
-```rust,ignore
-use rd2qmd_package::{ExternalLinkOptions, PackageConverter};
-use std::path::PathBuf;
+```rust
+use rd2qmd_package::{
+    ExternalLinkOptions, PackageConvertOptions, PackageConverter, RdPackage,
+};
+use std::path::{Path, PathBuf};
+
+let package = RdPackage::from_directory(Path::new("man"), false)?;
+let options = PackageConvertOptions {
+    output_dir: PathBuf::from("docs/reference"),
+    output_extension: "qmd".to_string(),
+    ..Default::default()
+};
 
 let result = PackageConverter::new(&package, options)
     .with_external_links(ExternalLinkOptions {

--- a/crates/rd2qmd-package/README.md
+++ b/crates/rd2qmd-package/README.md
@@ -18,7 +18,7 @@ This crate is designed to be used as a library by various interfaces (CLI, R pac
 
 ### Basic conversion
 
-```rust
+```rust,no_run
 use rd2qmd_package::{RdPackage, PackageConvertOptions, PackageConverter};
 use std::path::{Path, PathBuf};
 
@@ -35,7 +35,7 @@ println!("Converted {} files", result.conversion.success_count);
 
 ### Topic index generation
 
-```rust
+```rust,no_run
 use rd2qmd_package::{RdPackage, TopicIndexOptions, generate_topic_index};
 use std::path::Path;
 
@@ -50,7 +50,7 @@ println!("{}", index.to_json()?);
 
 ### External link resolution (requires `external-links` feature)
 
-```rust
+```rust,no_run
 use rd2qmd_package::{
     ExternalLinkOptions, PackageConvertOptions, PackageConverter, RdPackage,
 };

--- a/crates/rd2qmd-package/README.md
+++ b/crates/rd2qmd-package/README.md
@@ -18,7 +18,7 @@ This crate is designed to be used as a library by various interfaces (CLI, R pac
 
 ### Basic conversion
 
-```rust,no_run
+```rust,ignore
 use rd2qmd_package::{RdPackage, PackageConvertOptions, PackageConverter};
 use std::path::{Path, PathBuf};
 
@@ -35,7 +35,7 @@ println!("Converted {} files", result.conversion.success_count);
 
 ### Topic index generation
 
-```rust,no_run
+```rust,ignore
 use rd2qmd_package::{RdPackage, TopicIndexOptions, generate_topic_index};
 use std::path::Path;
 
@@ -50,7 +50,7 @@ println!("{}", index.to_json()?);
 
 ### External link resolution (requires `external-links` feature)
 
-```rust,no_run
+```rust,ignore
 use rd2qmd_package::{
     ExternalLinkOptions, PackageConvertOptions, PackageConverter, RdPackage,
 };


### PR DESCRIPTION
## Summary

- Add dedicated README.md for `rd2qmd-core` and `rd2qmd-package` packages (previously relying on workspace README, which provides poor UX on crates.io)
- Update `Cargo.toml` in both packages to point to their own README instead of `readme.workspace = true`
- Expand `convert` module documentation from 1 line to a detailed overview with entry points
- Add doc comments to `rd_to_mdast` and `rd_to_mdast_with_options` functions

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --doc -p rd2qmd-core` passes (6/6 doc tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)