### PR TITLE
fix(rd-parser): preserve zero-arg macro terminators and literal braces in code sections

### DIFF
--- a/crates/rd-parser/src/lexer.rs
+++ b/crates/rd-parser/src/lexer.rs
@@ -238,18 +238,11 @@ impl<'a> Lexer<'a> {
 
     /// Consume text until a special character
     ///
-    /// FIXME: This function treats parentheses and other punctuation as part of text,
-    /// which causes issues when parsing macros like `\dots)`. The `)` gets included
-    /// in the macro name, resulting in `macro{name:"dots)"}` instead of the special
-    /// character `\dots` followed by text `)`.
-    ///
-    /// According to parseRd.pdf, macro names should only consist of alphanumeric
-    /// characters. A proper fix would require either:
-    /// 1. Making the lexer context-aware (knowing when it's after a backslash)
-    /// 2. Handling macro name termination in the parser
-    /// 3. Tokenizing punctuation separately
-    ///
-    /// See snapshot test `nested` for an example of this behavior.
+    /// Punctuation (e.g. `)`, `,`, `.`) is included in text tokens. This means
+    /// a sequence like `dots)` after `\` becomes `Text("dots)")`. The parser's
+    /// `parse_macro_name` handles this by splitting at the first non-alphanumeric
+    /// character, since Rd macro names consist only of ASCII alphanumeric characters
+    /// per parseRd.pdf.
     fn consume_text(&mut self) -> String {
         let mut text = String::new();
         while let Some(ch) = self.peek() {

--- a/crates/rd-parser/src/parser.rs
+++ b/crates/rd-parser/src/parser.rs
@@ -640,6 +640,7 @@ impl Parser {
                     match self.peek_kind() {
                         TokenKind::Text(name) if name == "tab" => {
                             self.advance();
+                            self.consume_optional_empty_braces();
                             if !current_text.is_empty() {
                                 current_cell.push(RdNode::Text(std::mem::take(&mut current_text)));
                             }
@@ -647,6 +648,7 @@ impl Parser {
                         }
                         TokenKind::Text(name) if name == "cr" => {
                             self.advance();
+                            self.consume_optional_empty_braces();
                             if !current_text.is_empty() {
                                 current_cell.push(RdNode::Text(std::mem::take(&mut current_text)));
                             }
@@ -1892,6 +1894,25 @@ test(x, y = TRUE)
                 !text.contains("{}"),
                 "Input {input:?}: empty {{}} terminator must not appear in text, got: {text:?}"
             );
+        }
+    }
+
+    /// `\tab{}` and `\cr{}` inside `\tabular{}` must consume the empty `{}`
+    /// without leaving stray tokens that corrupt the table parse.
+    #[test]
+    fn test_tabular_tab_cr_with_empty_brace_terminator() {
+        // \tab{} — empty brace after cell separator
+        let doc = parse(r#"\details{\tabular{ll}{a \tab{} b \cr{} c \tab{} d \cr}}"#).unwrap();
+        let content = &doc.sections[0].content;
+        if let RdNode::Tabular { alignment, rows } = &content[0] {
+            assert_eq!(alignment, "ll");
+            assert_eq!(rows.len(), 2, "Expected 2 rows, got: {rows:?}");
+            // Row 1: cells "a " and " b "
+            assert_eq!(rows[0].len(), 2, "Expected 2 cells in row 1");
+            // Row 2: cells "c " and " d "
+            assert_eq!(rows[1].len(), 2, "Expected 2 cells in row 2");
+        } else {
+            panic!("Expected Tabular node, got {:?}", content[0]);
         }
     }
 

--- a/crates/rd-parser/src/parser.rs
+++ b/crates/rd-parser/src/parser.rs
@@ -215,12 +215,26 @@ impl Parser {
 
         let name = self.parse_macro_name()?;
 
-        // Handle special characters (no braces needed)
+        // Handle special characters (no braces needed).
+        // Consume an immediately following empty `{}` terminator if present —
+        // a common Rd idiom to unambiguously end a zero-arg macro (e.g. `\dots{}`).
         match name.as_str() {
-            "R" => return Ok(Some(RdNode::Special(SpecialChar::R))),
-            "dots" | "ldots" => return Ok(Some(RdNode::Special(SpecialChar::Dots))),
-            "cr" => return Ok(Some(RdNode::LineBreak)),
-            "tab" => return Ok(Some(RdNode::Tab)),
+            "R" => {
+                self.consume_optional_empty_braces();
+                return Ok(Some(RdNode::Special(SpecialChar::R)));
+            }
+            "dots" | "ldots" => {
+                self.consume_optional_empty_braces();
+                return Ok(Some(RdNode::Special(SpecialChar::Dots)));
+            }
+            "cr" => {
+                self.consume_optional_empty_braces();
+                return Ok(Some(RdNode::LineBreak));
+            }
+            "tab" => {
+                self.consume_optional_empty_braces();
+                return Ok(Some(RdNode::Tab));
+            }
             _ => {}
         }
 
@@ -1006,6 +1020,19 @@ impl Parser {
                 line: token.map(|t| t.span.line).unwrap_or(0),
                 col: token.map(|t| t.span.column).unwrap_or(0),
             })
+        }
+    }
+
+    /// Consume an immediately adjacent empty `{}` if the next two tokens are
+    /// `OpenBrace` then `CloseBrace`. Used to silently drop the common Rd
+    /// idiom of terminating zero-arg macros with `{}` (e.g. `\dots{}`).
+    fn consume_optional_empty_braces(&mut self) {
+        if self.check(&TokenKind::OpenBrace)
+            && self.pos + 1 < self.tokens.len()
+            && self.tokens[self.pos + 1].kind == TokenKind::CloseBrace
+        {
+            self.advance(); // {
+            self.advance(); // }
         }
     }
 
@@ -1839,6 +1866,32 @@ test(x, y = TRUE)
             );
         } else {
             panic!("Expected DontRun node, got {:?}", content[0]);
+        }
+    }
+
+    /// `\dots{}` in a code section must produce `SpecialChar::Dots` only —
+    /// the empty `{}` terminator must not be preserved as literal text `"{}"`.
+    #[test]
+    fn test_zero_arg_macro_empty_brace_terminator_not_preserved() {
+        for input in &[
+            r#"\usage{f(\dots{})}"#,
+            r#"\usage{f(\ldots{})}"#,
+            r#"\examples{f(\dots{})}"#,
+        ] {
+            let doc = parse(input).unwrap();
+            let content = &doc.sections[0].content;
+            let has_dots = content
+                .iter()
+                .any(|n| matches!(n, RdNode::Special(SpecialChar::Dots)));
+            assert!(has_dots, "Input {input:?}: expected SpecialChar::Dots");
+            let text: String = content
+                .iter()
+                .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+                .collect();
+            assert!(
+                !text.contains("{}"),
+                "Input {input:?}: empty {{}} terminator must not appear in text, got: {text:?}"
+            );
         }
     }
 

--- a/crates/rd-parser/src/parser.rs
+++ b/crates/rd-parser/src/parser.rs
@@ -36,6 +36,9 @@ pub type ParseResult<T> = Result<T, ParseError>;
 pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
+    /// When true, bare `{...}` in content is treated as literal text rather than Rd grouping.
+    /// Used for R code contexts like `\examples{}` and `\usage{}` where braces are R syntax.
+    preserve_braces: bool,
 }
 
 impl Parser {
@@ -44,6 +47,7 @@ impl Parser {
         Self {
             tokens: Lexer::tokenize(source),
             pos: 0,
+            preserve_braces: false,
         }
     }
 
@@ -91,7 +95,14 @@ impl Parser {
             }));
         }
 
+        // R code sections preserve literal braces (R syntax) rather than treating them
+        // as Rd text grouping.
+        let prev_preserve = self.preserve_braces;
+        if matches!(tag, SectionTag::Usage | SectionTag::Examples) {
+            self.preserve_braces = true;
+        }
         let content = self.parse_braced_content()?;
+        self.preserve_braces = prev_preserve;
 
         Ok(Some(RdSection { tag, content }))
     }
@@ -137,14 +148,34 @@ impl Parser {
                     }
                 }
                 TokenKind::OpenBrace => {
-                    // Nested braces - treat as text group
-                    if !current_text.is_empty() {
-                        nodes.push(RdNode::Text(std::mem::take(&mut current_text)));
+                    if self.preserve_braces {
+                        // In R code contexts (examples, usage), braces are literal R syntax.
+                        current_text.push('{');
+                        self.advance();
+                        let inner = self.parse_content_until_close_brace()?;
+                        self.expect(&TokenKind::CloseBrace)?;
+                        for inner_node in inner {
+                            match inner_node {
+                                RdNode::Text(s) => current_text.push_str(&s),
+                                other => {
+                                    if !current_text.is_empty() {
+                                        nodes.push(RdNode::Text(std::mem::take(&mut current_text)));
+                                    }
+                                    nodes.push(other);
+                                }
+                            }
+                        }
+                        current_text.push('}');
+                    } else {
+                        // In text contexts, nested braces are Rd grouping: unwrap inner content.
+                        if !current_text.is_empty() {
+                            nodes.push(RdNode::Text(std::mem::take(&mut current_text)));
+                        }
+                        self.advance();
+                        let inner = self.parse_content_until_close_brace()?;
+                        self.expect(&TokenKind::CloseBrace)?;
+                        nodes.extend(inner);
                     }
-                    self.advance();
-                    let inner = self.parse_content_until_close_brace()?;
-                    self.expect(&TokenKind::CloseBrace)?;
-                    nodes.extend(inner);
                 }
                 TokenKind::Text(s) => {
                     current_text.push_str(&s);
@@ -283,11 +314,33 @@ impl Parser {
     }
 
     /// Parse macro name (text following backslash)
+    ///
+    /// Macro names consist only of ASCII alphanumeric characters per parseRd.pdf.
+    /// If the text token has a non-alphanumeric suffix (e.g. `dots)` after `\`),
+    /// only the alphanumeric prefix is consumed as the name and the remainder is
+    /// reinserted into the token stream so it can be parsed as text content.
     fn parse_macro_name(&mut self) -> ParseResult<String> {
         match self.peek_kind() {
             TokenKind::Text(s) => {
-                let name = s.clone();
+                let alpha_end = s
+                    .find(|c: char| !c.is_ascii_alphanumeric())
+                    .unwrap_or(s.len());
+                if alpha_end == 0 {
+                    return Ok(String::new());
+                }
+                let name = s[..alpha_end].to_string();
+                let rest = s[alpha_end..].to_string();
+                let span = self.peek().map(|t| t.span).unwrap_or_default();
                 self.advance();
+                if !rest.is_empty() {
+                    self.tokens.insert(
+                        self.pos,
+                        Token {
+                            kind: TokenKind::Text(rest),
+                            span,
+                        },
+                    );
+                }
                 Ok(name)
             }
             // Special single-character escapes
@@ -1358,8 +1411,7 @@ test(x, y = TRUE)
 
     #[test]
     fn test_ldots() {
-        // \ldots should produce the same output as \dots
-        // Note: Use {} or space after macro name to properly terminate
+        // \ldots is an alias for \dots and should produce SpecialChar::Dots
         let doc = parse(r#"\description{a, b, \ldots{}, z}"#).unwrap();
         let content = &doc.sections[0].content;
         assert!(
@@ -1685,5 +1737,121 @@ test(x, y = TRUE)
         } else {
             panic!("Expected Sexpr node, got {:?}", content[0]);
         }
+    }
+
+    // ========================================================================
+    // Regression tests for GitHub issue #20: zero-arg macro terminator and
+    // literal braces in deparsed Rd examples
+    // ========================================================================
+
+    /// Rd macro names consist only of ASCII alphanumeric characters.
+    /// A zero-arg macro immediately followed by any non-alphanumeric character
+    /// must be recognized as the macro + preserved literal text, regardless of
+    /// which punctuation character follows.
+    #[test]
+    fn test_zero_arg_macro_terminates_at_non_alphanumeric() {
+        // (input, expected terminator char)
+        let cases: &[(&str, char)] = &[
+            (r#"\usage{\dots)}"#, ')'),
+            (r#"\usage{\dots,}"#, ','),
+            (r#"\usage{\dots.}"#, '.'),
+            (r#"\usage{\ldots)}"#, ')'),
+        ];
+        for &(input, expected_char) in cases {
+            let doc = parse(input).unwrap();
+            let content = &doc.sections[0].content;
+            let has_dots = content
+                .iter()
+                .any(|n| matches!(n, RdNode::Special(SpecialChar::Dots)));
+            assert!(
+                has_dots,
+                "Input {input:?}: expected SpecialChar::Dots, got: {content:?}"
+            );
+            let text: String = content
+                .iter()
+                .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+                .collect();
+            assert!(
+                text.contains(expected_char),
+                "Input {input:?}: expected {expected_char:?} preserved in text, got: {text:?}"
+            );
+        }
+    }
+
+    /// Literal `{` `}` in `\examples{}` must be preserved in the AST text
+    /// (they are R code syntax, not Rd grouping braces).
+    #[test]
+    fn test_examples_preserves_literal_braces() {
+        let doc = parse(
+            r#"\examples{hilbert <- function(n) { i <- 1:n; 1 / outer(i - 1, i, `+`) }}"#,
+        )
+        .unwrap();
+        let content = &doc.sections[0].content;
+        let text = content
+            .iter()
+            .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+            .collect::<String>();
+        assert!(
+            text.contains("{ i <- 1:n"),
+            "Expected literal '{{' preserved in examples, full text: {:?}",
+            text
+        );
+        assert!(
+            text.ends_with('}') || text.contains("} }") || text.contains("`) }"),
+            "Expected literal '}}' preserved in examples, full text: {:?}",
+            text
+        );
+    }
+
+    /// Literal `{` `}` in `\usage{}` must also be preserved.
+    #[test]
+    fn test_usage_preserves_literal_braces() {
+        let doc = parse(r#"\usage{f <- function(x) { x + 1 }}"#).unwrap();
+        let content = &doc.sections[0].content;
+        let text = content
+            .iter()
+            .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+            .collect::<String>();
+        assert!(
+            text.contains("{ x + 1 }"),
+            "Expected literal braces preserved in usage, full text: {:?}",
+            text
+        );
+    }
+
+    /// Braces in `\dontrun{}` inside `\examples{}` should also be preserved.
+    #[test]
+    fn test_examples_dontrun_preserves_braces() {
+        let doc = parse(
+            r#"\examples{\dontrun{f <- function(x) { x + 1 }}}"#,
+        )
+        .unwrap();
+        let content = &doc.sections[0].content;
+        if let RdNode::DontRun(children) = &content[0] {
+            let text = children
+                .iter()
+                .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+                .collect::<String>();
+            assert!(
+                text.contains("{ x + 1 }"),
+                "Expected literal braces preserved inside \\dontrun, full text: {:?}",
+                text
+            );
+        } else {
+            panic!("Expected DontRun node, got {:?}", content[0]);
+        }
+    }
+
+    /// In non-code sections (e.g. `\description{}`), bare `{{...}}` remains
+    /// Rd text grouping: the braces are unwrapped and the inner content is kept.
+    #[test]
+    fn test_description_unwraps_grouping_braces() {
+        let doc = parse(r#"\description{{grouped text}}"#).unwrap();
+        let content = &doc.sections[0].content;
+        let text = content
+            .iter()
+            .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+            .collect::<String>();
+        assert_eq!(text, "grouped text");
     }
 }

--- a/crates/rd-parser/src/parser.rs
+++ b/crates/rd-parser/src/parser.rs
@@ -1798,7 +1798,13 @@ test(x, y = TRUE)
             );
             let text: String = content
                 .iter()
-                .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+                .filter_map(|n| {
+                    if let RdNode::Text(s) = n {
+                        Some(s.as_str())
+                    } else {
+                        None
+                    }
+                })
                 .collect();
             assert!(
                 text.contains(expected_char),
@@ -1811,14 +1817,19 @@ test(x, y = TRUE)
     /// (they are R code syntax, not Rd grouping braces).
     #[test]
     fn test_examples_preserves_literal_braces() {
-        let doc = parse(
-            r#"\examples{hilbert <- function(n) { i <- 1:n; 1 / outer(i - 1, i, `+`) }}"#,
-        )
-        .unwrap();
+        let doc =
+            parse(r#"\examples{hilbert <- function(n) { i <- 1:n; 1 / outer(i - 1, i, `+`) }}"#)
+                .unwrap();
         let content = &doc.sections[0].content;
         let text = content
             .iter()
-            .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+            .filter_map(|n| {
+                if let RdNode::Text(s) = n {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            })
             .collect::<String>();
         assert!(
             text.contains("{ i <- 1:n"),
@@ -1839,7 +1850,13 @@ test(x, y = TRUE)
         let content = &doc.sections[0].content;
         let text = content
             .iter()
-            .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+            .filter_map(|n| {
+                if let RdNode::Text(s) = n {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            })
             .collect::<String>();
         assert!(
             text.contains("{ x + 1 }"),
@@ -1851,15 +1868,18 @@ test(x, y = TRUE)
     /// Braces in `\dontrun{}` inside `\examples{}` should also be preserved.
     #[test]
     fn test_examples_dontrun_preserves_braces() {
-        let doc = parse(
-            r#"\examples{\dontrun{f <- function(x) { x + 1 }}}"#,
-        )
-        .unwrap();
+        let doc = parse(r#"\examples{\dontrun{f <- function(x) { x + 1 }}}"#).unwrap();
         let content = &doc.sections[0].content;
         if let RdNode::DontRun(children) = &content[0] {
             let text = children
                 .iter()
-                .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+                .filter_map(|n| {
+                    if let RdNode::Text(s) = n {
+                        Some(s.as_str())
+                    } else {
+                        None
+                    }
+                })
                 .collect::<String>();
             assert!(
                 text.contains("{ x + 1 }"),
@@ -1888,7 +1908,13 @@ test(x, y = TRUE)
             assert!(has_dots, "Input {input:?}: expected SpecialChar::Dots");
             let text: String = content
                 .iter()
-                .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+                .filter_map(|n| {
+                    if let RdNode::Text(s) = n {
+                        Some(s.as_str())
+                    } else {
+                        None
+                    }
+                })
                 .collect();
             assert!(
                 !text.contains("{}"),
@@ -1924,7 +1950,13 @@ test(x, y = TRUE)
         let content = &doc.sections[0].content;
         let text = content
             .iter()
-            .filter_map(|n| if let RdNode::Text(s) = n { Some(s.as_str()) } else { None })
+            .filter_map(|n| {
+                if let RdNode::Text(s) = n {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            })
             .collect::<String>();
         assert_eq!(text, "grouped text");
     }

--- a/crates/rd-parser/tests/snapshots/parser_snapshots__escapes.snap
+++ b/crates/rd-parser/tests/snapshots/parser_snapshots__escapes.snap
@@ -33,13 +33,10 @@ expression: ast_json
           "text": " for ellipsis instead of "
         },
         {
-          "macro": {
-            "name": "dots.",
-            "args": []
-          }
+          "special": "dots"
         },
         {
-          "text": "\nPercent sign: 100% complete.\nBackslash: C:\\path\\to\\file\n"
+          "text": ".\nPercent sign: 100% complete.\nBackslash: C:\\path\\to\\file\n"
         }
       ]
     },
@@ -62,13 +59,10 @@ expression: ast_json
           "text": " produce an ellipsis: a, b, "
         },
         {
-          "macro": {
-            "name": "dots,",
-            "args": []
-          }
+          "special": "dots"
         },
         {
-          "text": "z.\n"
+          "text": ", z.\n"
         }
       ]
     }

--- a/crates/rd-parser/tests/snapshots/parser_snapshots__nested.snap
+++ b/crates/rd-parser/tests/snapshots/parser_snapshots__nested.snap
@@ -111,10 +111,10 @@ expression: ast_json
               "text": "(x, "
             },
             {
-              "macro": {
-                "name": "dots)",
-                "args": []
-              }
+              "special": "dots"
+            },
+            {
+              "text": ")"
             }
           ]
         },


### PR DESCRIPTION
## Summary

- **Bug 1**: `\dots)`, `\dots,`, `\ldots)` etc. were parsed as macro `dots)` / `dots,` because the lexer includes punctuation in text tokens. Fixed by splitting at the first non-ASCII-alphanumeric character in `parse_macro_name()`, per the Rd spec that macro names consist only of ASCII alphanumeric characters.
- **Bug 2**: Literal braces in `\usage{}` and `\examples{}` sections (e.g. `f(a = list(x = 1))`) were being unwrapped as Rd text grouping. Fixed by adding a `preserve_braces` flag to `Parser`, set to `true` for `usage`/`examples` sections.
- **Additional**: `\dots{}` / `\tab{}` / `\cr{}` idiom (empty `{}` used to terminate zero-arg macros in Rd source) was incorrectly preserved as literal `{}` output. Fixed with a `consume_optional_empty_braces()` helper called after zero-arg macro early returns and in the `parse_tabular()` fast-path.

Fixes https://github.com/eitsupi/rd2qmd/issues/20

## Test plan

- [ ] `cargo test -p rd-parser` passes
- [ ] `test_zero_arg_macro_terminates_at_non_alphanumeric` covers `)`, `,`, `.`, and `\ldots)`
- [ ] `test_zero_arg_macro_empty_brace_terminator_not_preserved` verifies `\dots{}` → `...` (no stray `{}`)
- [ ] `test_tabular_tab_cr_with_empty_brace_terminator` verifies `\tab{}` / `\cr{}` in tabular context
- [ ] `test_examples_preserves_literal_braces` / `test_usage_preserves_literal_braces` verify brace preservation in code sections
- [ ] `test_description_unwraps_grouping_braces` verifies non-code sections still unwrap grouping braces
- [ ] Snapshot tests updated for `escapes` and `nested` (old snapshots captured buggy behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)