### PR TITLE
refactor!: rename grid/pipe to grid-table/pipe-table and default to list-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,13 @@ Use `-f md` for standard markdown with:
 
 ### Arguments table format
 
-The Arguments section is rendered as a table. Use `--arguments-table` to select the format:
+The Arguments section is rendered as a table. Rd argument descriptions can contain rich content such as lists and multiple paragraphs — `pipe-table` cannot fully represent this and flattens it with `<br>`. Use `--arguments-table` to select the format based on your target renderer:
 
-| Format | `list-table` (default) | `grid-table` | `pipe-table` |
+| | `list-table` (default) | `grid-table` | `pipe-table` |
 |---|---|---|---|
-| Block elements in cells | ✅ | ✅ | ❌ (flattened with `<br>`) |
-| Quarto 1.x | ✅ (requires 1.9+) | ✅ | ✅ |
-| Quarto 2 / q2 | ✅ | ❌ | ✅ |
-| Pandoc (without filters) | ❌ | ✅ | ✅ |
+| Quarto 1.9+ | ✅ | ✅ | ✅ |
+| Quarto 2 (q2) | ✅ | ❌ | ✅ |
+| Plain Pandoc / Quarto < 1.9 | ❌ | ✅ | ✅ |
 | GFM / general Markdown | ❌ | ❌ | ✅ |
 
 **`list-table`** (default) — Quarto native syntax, supports full block elements. Recommended for Quarto 1.9+ and q2 workflows:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A fast Rd-to-Quarto Markdown converter written in Rust, with intelligent link re
 - **External package links**: Resolves cross-package links using pkgdown URL conventions (e.g., `\link[dplyr]{mutate}` → `https://dplyr.tidyverse.org/reference/mutate.html`)
 - **Topic index generation**: Outputs JSON index with topic metadata (name, title, aliases, lifecycle) for building reference sites
 - **Quarto-ready**: Generates `.qmd` files with `{r}` executable code blocks and YAML frontmatter
-- **Flexible Arguments tables**: Supports Pandoc Grid Tables (default), GFM Pipe Tables, and Quarto native List-Tables (`--arguments-table list-table`) for the Arguments section
+- **Flexible Arguments tables**: Supports Quarto native List-Tables (default), Pandoc Grid Tables, and GFM Pipe Tables for the Arguments section (`--arguments-table list-table|grid-table|pipe-table`)
 - **pkgdown-compatible metadata**: Adds `pagetitle` in pkgdown style (`"<title> — <name>"`) for SEO
 - **No R required**: Pure Rust binary with no runtime R dependency
 
@@ -78,7 +78,7 @@ rd2qmd man/ -o docs/ -j4
 | `--no-frontmatter` | Disable YAML frontmatter |
 | `--no-pagetitle` | Skip pkgdown-style `pagetitle` metadata (`"<title> — <name>"`) |
 | `--quarto-code-blocks <BOOL>` | Use `{r}` code blocks (auto-set based on format) |
-| `--arguments-table <FORMAT>` | Arguments table format: `grid` (default), `pipe`, or `list-table` |
+| `--arguments-table <FORMAT>` | Arguments table format: `list-table` (default), `grid-table`, or `pipe-table` |
 | `-v, --verbose` | Verbose output |
 | `-q, --quiet` | Only show errors |
 
@@ -175,33 +175,17 @@ Use `-f md` for standard markdown with:
 
 ### Arguments table format
 
-The Arguments section is rendered as a table. By default, rd2qmd uses **Pandoc Grid Tables** which support block elements (lists, multiple paragraphs) within cells:
+The Arguments section is rendered as a table. Use `--arguments-table` to select the format:
 
-```markdown
-+----------+-------------------------------------+
-| Argument | Description                         |
-+==========+=====================================+
-| `x`      | A simple description.               |
-+----------+-------------------------------------+
-| `opts`   | Available options:                  |
-|          |                                     |
-|          | - option A                          |
-|          | - option B                          |
-+----------+-------------------------------------+
-```
+| Format | `list-table` (default) | `grid-table` | `pipe-table` |
+|---|---|---|---|
+| Block elements in cells | ✅ | ✅ | ❌ (flattened with `<br>`) |
+| Quarto 1.x | ✅ (requires 1.9+) | ✅ | ✅ |
+| Quarto 2 / q2 | ✅ | ❌ | ✅ |
+| Pandoc (without filters) | ❌ | ✅ | ✅ |
+| GFM / general Markdown | ❌ | ❌ | ✅ |
 
-For Markdown environments that don't support Grid Tables, use `--arguments-table pipe` for pipe tables:
-
-```markdown
-| Argument | Description |
-|:---|:---|
-| `x` | A simple description. |
-| `opts` | Available options: <br>- option A <br>- option B |
-```
-
-Note: GFM tables cannot contain true block elements; lists are flattened with `<br>` separators.
-
-Use `--arguments-table list-table` for Quarto native list-tables (requires Quarto 1.9+):
+**`list-table`** (default) — Quarto native syntax, supports full block elements. Recommended for Quarto 1.9+ and q2 workflows:
 
 ```markdown
 ::: {.list-table header-rows=1}
@@ -221,7 +205,29 @@ Use `--arguments-table list-table` for Quarto native list-tables (requires Quart
 :::
 ```
 
-List-tables support full block elements (nested lists, multiple paragraphs, code blocks) and render natively in Quarto without Pandoc extension dependencies.
+**`grid-table`** — Pandoc Grid Table syntax, supports block elements. Works with Quarto 1.x and plain Pandoc, but not supported in q2:
+
+```markdown
++----------+-------------------------------------+
+| Argument | Description                         |
++==========+=====================================+
+| `x`      | A simple description.               |
++----------+-------------------------------------+
+| `opts`   | Available options:                  |
+|          |                                     |
+|          | - option A                          |
+|          | - option B                          |
++----------+-------------------------------------+
+```
+
+**`pipe-table`** — Standard GFM pipe table. Broadest rendering compatibility (GitHub, most Markdown renderers), but block elements are flattened with `<br>`:
+
+```markdown
+| Argument | Description |
+|:---|:---|
+| `x` | A simple description. |
+| `opts` | Available options: <br>- option A <br>- option B |
+```
 
 ## Examples
 

--- a/crates/rd2qmd-cli/examples/benchmark.rs
+++ b/crates/rd2qmd-cli/examples/benchmark.rs
@@ -197,6 +197,7 @@ fn run_single_benchmark(
         exec_dontrun: false,
         exec_donttest: true,     // pkgdown-compatible default
         include_internal: false, // skip internal topics by default
+        arguments_format: rd2qmd_core::ArgumentsFormat::default(),
     };
 
     convert_package(package, &options)?;

--- a/crates/rd2qmd-cli/schema/rd2qmd.schema.json
+++ b/crates/rd2qmd-cli/schema/rd2qmd.schema.json
@@ -22,6 +22,26 @@
     }
   },
   "$defs": {
+    "ArgumentsTableFormat": {
+      "description": "Table format for the Arguments section",
+      "oneOf": [
+        {
+          "description": "Pipe table - limited to inline content",
+          "type": "string",
+          "const": "pipe-table"
+        },
+        {
+          "description": "Pandoc grid table - supports block elements (lists, paragraphs) in cells",
+          "type": "string",
+          "const": "grid-table"
+        },
+        {
+          "description": "Quarto list-table (default) - requires Quarto 1.9+, compatible with q2",
+          "type": "string",
+          "const": "list-table"
+        }
+      ]
+    },
     "CodeConfig": {
       "description": "Code block configuration",
       "type": "object",
@@ -104,10 +124,14 @@
       "type": "object",
       "properties": {
         "arguments_table": {
-          "description": "Table format for Arguments section: \"list-table\" (Quarto list-table, requires Quarto 1.9+), \"grid-table\" (Pandoc grid table), or \"pipe-table\" (GFM pipe table). Default: \"list-table\"",
-          "type": [
-            "string",
-            "null"
+          "description": "Table format for Arguments section (default: list-table)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArgumentsTableFormat"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "format": {

--- a/crates/rd2qmd-cli/schema/rd2qmd.schema.json
+++ b/crates/rd2qmd-cli/schema/rd2qmd.schema.json
@@ -104,7 +104,7 @@
       "type": "object",
       "properties": {
         "arguments_table": {
-          "description": "Table format for Arguments section: \"grid\" (Pandoc grid table), \"pipe\" (GFM pipe table), or \"list-table\" (Quarto list-table, requires Quarto 1.9+). Default: \"grid\"",
+          "description": "Table format for Arguments section: \"list-table\" (Quarto list-table, requires Quarto 1.9+), \"grid-table\" (Pandoc grid table), or \"pipe-table\" (GFM pipe table). Default: \"list-table\"",
           "type": [
             "string",
             "null"

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -7,6 +7,21 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+/// Table format for the Arguments section
+// All current variants end with `Table`, but future formats (e.g. list-based) may not.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArgumentsTableFormat {
+    /// Pipe table - limited to inline content
+    PipeTable,
+    /// Pandoc grid table - supports block elements (lists, paragraphs) in cells
+    GridTable,
+    /// Quarto list-table (default) - requires Quarto 1.9+, compatible with q2
+    #[default]
+    ListTable,
+}
+
 /// Default configuration file name (following Quarto's `_quarto.yml` convention)
 pub const CONFIG_FILE_NAME: &str = "_rd2qmd.toml";
 
@@ -44,9 +59,9 @@ pub struct OutputConfig {
     /// Add pkgdown-style pagetitle metadata ("<title> — <name>") (default: true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagetitle: Option<bool>,
-    /// Table format for Arguments section: "list-table" (Quarto list-table, requires Quarto 1.9+), "grid-table" (Pandoc grid table), or "pipe-table" (GFM pipe table). Default: "list-table"
+    /// Table format for Arguments section (default: list-table)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub arguments_table: Option<String>,
+    pub arguments_table: Option<ArgumentsTableFormat>,
     /// Include topics with \keyword{internal} (default: false)
     /// By default, internal topics are skipped (matching pkgdown behavior).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -179,7 +194,7 @@ impl Config {
                 format: Some("qmd".to_string()),
                 frontmatter: Some(true),
                 pagetitle: Some(true),
-                arguments_table: Some("list-table".to_string()),
+                arguments_table: Some(ArgumentsTableFormat::ListTable),
                 include_internal: Some(false),
             },
             code: CodeConfig {
@@ -229,7 +244,7 @@ mod tests {
         assert_eq!(config.output.pagetitle, Some(true));
         assert_eq!(
             config.output.arguments_table,
-            Some("pipe-table".to_string())
+            Some(ArgumentsTableFormat::PipeTable)
         );
     }
 

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -44,7 +44,7 @@ pub struct OutputConfig {
     /// Add pkgdown-style pagetitle metadata ("<title> — <name>") (default: true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagetitle: Option<bool>,
-    /// Table format for Arguments section: "grid" (Pandoc grid table), "pipe" (GFM pipe table), or "list-table" (Quarto list-table, requires Quarto 1.9+). Default: "grid"
+    /// Table format for Arguments section: "list-table" (Quarto list-table, requires Quarto 1.9+), "grid-table" (Pandoc grid table), or "pipe-table" (GFM pipe table). Default: "list-table"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments_table: Option<String>,
     /// Include topics with \keyword{internal} (default: false)
@@ -179,7 +179,7 @@ impl Config {
                 format: Some("qmd".to_string()),
                 frontmatter: Some(true),
                 pagetitle: Some(true),
-                arguments_table: Some("grid".to_string()),
+                arguments_table: Some("list-table".to_string()),
                 include_internal: Some(false),
             },
             code: CodeConfig {
@@ -219,7 +219,7 @@ mod tests {
             format = "md"
             frontmatter = false
             pagetitle = true
-            arguments_table = "pipe"
+            arguments_table = "pipe-table"
             "#,
         )
         .unwrap();
@@ -227,7 +227,7 @@ mod tests {
         assert_eq!(config.output.format, Some("md".to_string()));
         assert_eq!(config.output.frontmatter, Some(false));
         assert_eq!(config.output.pagetitle, Some(true));
-        assert_eq!(config.output.arguments_table, Some("pipe".to_string()));
+        assert_eq!(config.output.arguments_table, Some("pipe-table".to_string()));
     }
 
     #[test]
@@ -299,7 +299,7 @@ mod tests {
             format = "qmd"
             frontmatter = true
             pagetitle = true
-            arguments_table = "grid"
+            arguments_table = "grid-table"
 
             [code]
             quarto_code_blocks = true

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -10,7 +10,9 @@ use std::path::{Path, PathBuf};
 /// Table format for the Arguments section
 // All current variants end with `Table`, but future formats (e.g. list-based) may not.
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema, clap::ValueEnum)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema, clap::ValueEnum,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum ArgumentsTableFormat {
     /// Pipe table - limited to inline content

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -227,7 +227,10 @@ mod tests {
         assert_eq!(config.output.format, Some("md".to_string()));
         assert_eq!(config.output.frontmatter, Some(false));
         assert_eq!(config.output.pagetitle, Some(true));
-        assert_eq!(config.output.arguments_table, Some("pipe-table".to_string()));
+        assert_eq!(
+            config.output.arguments_table,
+            Some("pipe-table".to_string())
+        );
     }
 
     #[test]

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -34,7 +34,6 @@ enum OutputFormat {
     Rmd,
 }
 
-
 #[derive(Parser, Debug)]
 #[command(name = "rd2qmd")]
 #[command(about = "Convert Rd files to Quarto Markdown")]

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -38,11 +38,11 @@ enum OutputFormat {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
 enum ArgumentsTableFormat {
     /// Pipe table - limited to inline content
-    Pipe,
-    /// Pandoc grid table (default) - supports block elements (lists, paragraphs) in cells
+    PipeTable,
+    /// Pandoc grid table - supports block elements (lists, paragraphs) in cells
+    GridTable,
+    /// Quarto list-table (default) - requires Quarto 1.9+, compatible with q2
     #[default]
-    Grid,
-    /// Quarto list-table - requires Quarto 1.9+, compatible with q2
     ListTable,
 }
 
@@ -156,10 +156,10 @@ struct Cli {
     #[arg(long)]
     include_internal: bool,
 
-    /// Table format for the Arguments section: grid (Pandoc grid table), pipe (GFM pipe table),
-    /// or list-table (Quarto list-table, requires Quarto 1.9+, compatible with q2).
-    /// Grid and list-table support block elements (lists, paragraphs) in cells.
-    #[arg(long, value_enum, default_value_t = ArgumentsTableFormat::Grid)]
+    /// Table format for the Arguments section: list-table (Quarto list-table, default), grid-table
+    /// (Pandoc grid table), or pipe-table (GFM pipe table, inline content only).
+    /// List-table and grid-table support block elements (lists, paragraphs) in cells.
+    #[arg(long, value_enum, default_value_t = ArgumentsTableFormat::ListTable)]
     arguments_table: ArgumentsTableFormat,
 
     /// Generate topic index JSON file (directory mode only)
@@ -766,17 +766,17 @@ fn merge_unresolved_link_url(cli: &Cli, config: &Config) -> Option<String> {
 fn merge_arguments_format(cli: &Cli, config: &Config) -> ArgumentsFormat {
     // If config specifies a format, check if CLI is using the default
     if let Some(ref fmt) = config.output.arguments_table
-        && cli.arguments_table == ArgumentsTableFormat::Grid
+        && cli.arguments_table == ArgumentsTableFormat::ListTable
     {
         return match fmt.to_lowercase().as_str() {
-            "pipe" => ArgumentsFormat::PipeTable,
-            "list-table" => ArgumentsFormat::ListTable,
-            _ => ArgumentsFormat::GridTable,
+            "pipe-table" => ArgumentsFormat::PipeTable,
+            "grid-table" => ArgumentsFormat::GridTable,
+            _ => ArgumentsFormat::ListTable,
         };
     }
     match cli.arguments_table {
-        ArgumentsTableFormat::Pipe => ArgumentsFormat::PipeTable,
-        ArgumentsTableFormat::Grid => ArgumentsFormat::GridTable,
+        ArgumentsTableFormat::PipeTable => ArgumentsFormat::PipeTable,
+        ArgumentsTableFormat::GridTable => ArgumentsFormat::GridTable,
         ArgumentsTableFormat::ListTable => ArgumentsFormat::ListTable,
     }
 }
@@ -847,7 +847,7 @@ mod tests {
             exec_dontrun: false,
             no_exec_donttest: false,
             include_internal: false,
-            arguments_table: ArgumentsTableFormat::Grid,
+            arguments_table: ArgumentsTableFormat::ListTable,
             topic_index: None,
             config: None,
             no_config: false,
@@ -1000,7 +1000,7 @@ mod tests {
         let config = Config::default();
         assert_eq!(
             merge_arguments_format(&cli, &config),
-            ArgumentsFormat::GridTable
+            ArgumentsFormat::ListTable
         );
     }
 
@@ -1009,7 +1009,7 @@ mod tests {
         let cli = default_cli();
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some("pipe".to_string()),
+                arguments_table: Some("pipe-table".to_string()),
                 ..Default::default()
             },
             ..Default::default()
@@ -1023,15 +1023,15 @@ mod tests {
     #[test]
     fn test_merge_arguments_format_cli_overrides() {
         let mut cli = default_cli();
-        cli.arguments_table = ArgumentsTableFormat::Pipe;
+        cli.arguments_table = ArgumentsTableFormat::PipeTable;
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some("grid".to_string()),
+                arguments_table: Some("grid-table".to_string()),
                 ..Default::default()
             },
             ..Default::default()
         };
-        // CLI is not default (Grid), so CLI wins
+        // CLI is not default (ListTable), so CLI wins
         assert_eq!(
             merge_arguments_format(&cli, &config),
             ArgumentsFormat::PipeTable

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -35,6 +35,8 @@ enum OutputFormat {
 }
 
 /// Table format for the Arguments section
+// All current variants end with `Table`, but future formats (e.g. list-based) may not.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
 enum ArgumentsTableFormat {
     /// Pipe table - limited to inline content

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -159,8 +159,8 @@ struct Cli {
     /// Table format for the Arguments section: list-table (Quarto list-table, default), grid-table
     /// (Pandoc grid table), or pipe-table (GFM pipe table, inline content only).
     /// List-table and grid-table support block elements (lists, paragraphs) in cells.
-    #[arg(long, value_enum, default_value_t = ArgumentsTableFormat::ListTable)]
-    arguments_table: ArgumentsTableFormat,
+    #[arg(long, value_enum)]
+    arguments_table: Option<ArgumentsTableFormat>,
 
     /// Generate topic index JSON file (directory mode only)
     /// Contains topic names, files, titles, aliases, and lifecycle stages
@@ -329,6 +329,7 @@ fn main() -> Result<()> {
             exec_dontrun,
             exec_donttest,
             include_internal,
+            arguments_format,
             cli.topic_index.as_deref(),
             cli.verbose,
             cli.quiet,
@@ -421,6 +422,7 @@ fn convert_directory(
     exec_dontrun: bool,
     exec_donttest: bool,
     include_internal: bool,
+    arguments_format: ArgumentsFormat,
     topic_index_path: Option<&Path>,
     verbose: bool,
     quiet: bool,
@@ -466,6 +468,7 @@ fn convert_directory(
         exec_dontrun,
         exec_donttest,
         include_internal,
+        arguments_format,
     };
 
     // Convert external link options
@@ -762,23 +765,23 @@ fn merge_unresolved_link_url(cli: &Cli, config: &Config) -> Option<String> {
     )
 }
 
-/// Merge arguments table format
+/// Merge arguments table format: explicit CLI > config > default (list-table)
 fn merge_arguments_format(cli: &Cli, config: &Config) -> ArgumentsFormat {
-    // If config specifies a format, check if CLI is using the default
-    if let Some(ref fmt) = config.output.arguments_table
-        && cli.arguments_table == ArgumentsTableFormat::ListTable
-    {
+    if let Some(fmt) = cli.arguments_table {
+        return match fmt {
+            ArgumentsTableFormat::PipeTable => ArgumentsFormat::PipeTable,
+            ArgumentsTableFormat::GridTable => ArgumentsFormat::GridTable,
+            ArgumentsTableFormat::ListTable => ArgumentsFormat::ListTable,
+        };
+    }
+    if let Some(ref fmt) = config.output.arguments_table {
         return match fmt.to_lowercase().as_str() {
             "pipe-table" => ArgumentsFormat::PipeTable,
             "grid-table" => ArgumentsFormat::GridTable,
             _ => ArgumentsFormat::ListTable,
         };
     }
-    match cli.arguments_table {
-        ArgumentsTableFormat::PipeTable => ArgumentsFormat::PipeTable,
-        ArgumentsTableFormat::GridTable => ArgumentsFormat::GridTable,
-        ArgumentsTableFormat::ListTable => ArgumentsFormat::ListTable,
-    }
+    ArgumentsFormat::ListTable
 }
 
 /// Merge external link options
@@ -847,7 +850,7 @@ mod tests {
             exec_dontrun: false,
             no_exec_donttest: false,
             include_internal: false,
-            arguments_table: ArgumentsTableFormat::ListTable,
+            arguments_table: None,
             topic_index: None,
             config: None,
             no_config: false,
@@ -1023,7 +1026,7 @@ mod tests {
     #[test]
     fn test_merge_arguments_format_cli_overrides() {
         let mut cli = default_cli();
-        cli.arguments_table = ArgumentsTableFormat::PipeTable;
+        cli.arguments_table = Some(ArgumentsTableFormat::PipeTable);
         let config = Config {
             output: config::OutputConfig {
                 arguments_table: Some("grid-table".to_string()),
@@ -1031,10 +1034,28 @@ mod tests {
             },
             ..Default::default()
         };
-        // CLI is not default (ListTable), so CLI wins
+        // CLI is explicitly set, so CLI wins over config
         assert_eq!(
             merge_arguments_format(&cli, &config),
             ArgumentsFormat::PipeTable
+        );
+    }
+
+    #[test]
+    fn test_merge_arguments_format_list_table_cli_overrides_config() {
+        let mut cli = default_cli();
+        cli.arguments_table = Some(ArgumentsTableFormat::ListTable);
+        let config = Config {
+            output: config::OutputConfig {
+                arguments_table: Some("grid-table".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // Explicit --arguments-table list-table must override config grid-table
+        assert_eq!(
+            merge_arguments_format(&cli, &config),
+            ArgumentsFormat::ListTable
         );
     }
 

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -4,7 +4,7 @@ mod config;
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
-use config::Config;
+use config::{ArgumentsTableFormat, Config};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -34,19 +34,6 @@ enum OutputFormat {
     Rmd,
 }
 
-/// Table format for the Arguments section
-// All current variants end with `Table`, but future formats (e.g. list-based) may not.
-#[allow(clippy::enum_variant_names)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
-enum ArgumentsTableFormat {
-    /// Pipe table - limited to inline content
-    PipeTable,
-    /// Pandoc grid table - supports block elements (lists, paragraphs) in cells
-    GridTable,
-    /// Quarto list-table (default) - requires Quarto 1.9+, compatible with q2
-    #[default]
-    ListTable,
-}
 
 #[derive(Parser, Debug)]
 #[command(name = "rd2qmd")]
@@ -769,21 +756,15 @@ fn merge_unresolved_link_url(cli: &Cli, config: &Config) -> Option<String> {
 
 /// Merge arguments table format: explicit CLI > config > default (list-table)
 fn merge_arguments_format(cli: &Cli, config: &Config) -> ArgumentsFormat {
-    if let Some(fmt) = cli.arguments_table {
-        return match fmt {
-            ArgumentsTableFormat::PipeTable => ArgumentsFormat::PipeTable,
-            ArgumentsTableFormat::GridTable => ArgumentsFormat::GridTable,
-            ArgumentsTableFormat::ListTable => ArgumentsFormat::ListTable,
-        };
+    let fmt = cli
+        .arguments_table
+        .or(config.output.arguments_table)
+        .unwrap_or_default();
+    match fmt {
+        ArgumentsTableFormat::PipeTable => ArgumentsFormat::PipeTable,
+        ArgumentsTableFormat::GridTable => ArgumentsFormat::GridTable,
+        ArgumentsTableFormat::ListTable => ArgumentsFormat::ListTable,
     }
-    if let Some(ref fmt) = config.output.arguments_table {
-        return match fmt.to_lowercase().as_str() {
-            "pipe-table" => ArgumentsFormat::PipeTable,
-            "grid-table" => ArgumentsFormat::GridTable,
-            _ => ArgumentsFormat::ListTable,
-        };
-    }
-    ArgumentsFormat::ListTable
 }
 
 /// Merge external link options
@@ -1014,7 +995,7 @@ mod tests {
         let cli = default_cli();
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some("pipe-table".to_string()),
+                arguments_table: Some(ArgumentsTableFormat::PipeTable),
                 ..Default::default()
             },
             ..Default::default()
@@ -1031,7 +1012,7 @@ mod tests {
         cli.arguments_table = Some(ArgumentsTableFormat::PipeTable);
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some("grid-table".to_string()),
+                arguments_table: Some(ArgumentsTableFormat::GridTable),
                 ..Default::default()
             },
             ..Default::default()
@@ -1049,7 +1030,7 @@ mod tests {
         cli.arguments_table = Some(ArgumentsTableFormat::ListTable);
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some("grid-table".to_string()),
+                arguments_table: Some(ArgumentsTableFormat::GridTable),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -134,6 +134,33 @@ fn test_directory_conversion() {
 }
 
 #[test]
+fn test_directory_conversion_pipe_table() {
+    let fixtures = fixtures_dir();
+    let output_dir = std::env::temp_dir().join("rd2qmd_test_dir_pipe_table");
+
+    let _ = fs::remove_dir_all(&output_dir);
+    fs::create_dir_all(&output_dir).expect("Failed to create output dir");
+
+    let status = Command::new(rd2qmd_binary())
+        .arg(&fixtures)
+        .arg("-o")
+        .arg(&output_dir)
+        .arg("--arguments-table")
+        .arg("pipe-table")
+        .arg("-q")
+        .status()
+        .expect("Failed to run rd2qmd");
+
+    assert!(status.success(), "rd2qmd directory conversion failed");
+
+    let content =
+        fs::read_to_string(output_dir.join("simple.qmd")).expect("Failed to read simple.qmd");
+    let _ = fs::remove_dir_all(&output_dir);
+
+    insta::assert_snapshot!("directory_pipe_table_simple", content);
+}
+
+#[test]
 fn test_init_config() {
     let output_file = std::env::temp_dir().join("rd2qmd_test_init_config.toml");
     let _ = fs::remove_file(&output_file);

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -155,7 +155,7 @@ fn test_init_config() {
 
 #[test]
 fn test_simple_pipe_table() {
-    let output = convert_fixture("simple", &["--arguments-table", "pipe"]);
+    let output = convert_fixture("simple", &["--arguments-table", "pipe-table"]);
     insta::assert_snapshot!("simple_pipe_table", output);
 }
 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__directory_pipe_table_simple.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__directory_pipe_table_simple.snap
@@ -1,0 +1,40 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: content
+---
+---
+title: "A Simple Function"
+pagetitle: "A Simple Function — simple"
+aliases:
+  - "simple"
+---
+
+# A Simple Function
+
+## Description
+
+ This is a simple function for testing. 
+
+## Usage
+
+```r
+simple(x, y = 1)
+```
+
+## Arguments
+
+| Argument | Description |
+|:---|:---|
+| `x` | The first argument. |
+| `y` | The second argument, defaults to 1. |
+
+## Value
+
+ Returns the sum of `x` and `y`. 
+
+## Examples
+
+```{r}
+simple(1, 2)
+simple(10)
+```

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_config_toml.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_config_toml.snap
@@ -8,7 +8,7 @@ expression: content
 format = "qmd"
 frontmatter = true
 pagetitle = true
-arguments_table = "grid"
+arguments_table = "list-table"
 include_internal = false
 
 [code]

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
@@ -26,6 +26,26 @@ expression: schema
     }
   },
   "$defs": {
+    "ArgumentsTableFormat": {
+      "description": "Table format for the Arguments section",
+      "oneOf": [
+        {
+          "description": "Pipe table - limited to inline content",
+          "type": "string",
+          "const": "pipe-table"
+        },
+        {
+          "description": "Pandoc grid table - supports block elements (lists, paragraphs) in cells",
+          "type": "string",
+          "const": "grid-table"
+        },
+        {
+          "description": "Quarto list-table (default) - requires Quarto 1.9+, compatible with q2",
+          "type": "string",
+          "const": "list-table"
+        }
+      ]
+    },
     "CodeConfig": {
       "description": "Code block configuration",
       "type": "object",
@@ -108,10 +128,14 @@ expression: schema
       "type": "object",
       "properties": {
         "arguments_table": {
-          "description": "Table format for Arguments section: \"list-table\" (Quarto list-table, requires Quarto 1.9+), \"grid-table\" (Pandoc grid table), or \"pipe-table\" (GFM pipe table). Default: \"list-table\"",
-          "type": [
-            "string",
-            "null"
+          "description": "Table format for Arguments section (default: list-table)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArgumentsTableFormat"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "format": {

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rd2qmd-cli/tests/integration.rs
-assertion_line: 179
 expression: schema
 ---
 {
@@ -109,7 +108,7 @@ expression: schema
       "type": "object",
       "properties": {
         "arguments_table": {
-          "description": "Table format for Arguments section: \"grid\" (Pandoc grid table), \"pipe\" (GFM pipe table), or \"list-table\" (Quarto list-table, requires Quarto 1.9+). Default: \"grid\"",
+          "description": "Table format for Arguments section: \"list-table\" (Quarto list-table, requires Quarto 1.9+), \"grid-table\" (Pandoc grid table), or \"pipe-table\" (GFM pipe table). Default: \"list-table\"",
           "type": [
             "string",
             "null"

--- a/crates/rd2qmd-cli/tests/snapshots/integration__simple_md.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__simple_md.snap
@@ -23,13 +23,19 @@ simple(x, y = 1)
 
 ## Arguments
 
-+----------+-------------------------------------+
-| Argument | Description                         |
-+==========+=====================================+
-| `x`      | The first argument.                 |
-+----------+-------------------------------------+
-| `y`      | The second argument, defaults to 1. |
-+----------+-------------------------------------+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `x`
+  - The first argument.
+
+- - `y`
+  - The second argument, defaults to 1.
+
+:::
+
 ## Value
 
  Returns the sum of `x` and `y`. 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__simple_no_frontmatter.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__simple_no_frontmatter.snap
@@ -16,13 +16,19 @@ simple(x, y = 1)
 
 ## Arguments
 
-+----------+-------------------------------------+
-| Argument | Description                         |
-+==========+=====================================+
-| `x`      | The first argument.                 |
-+----------+-------------------------------------+
-| `y`      | The second argument, defaults to 1. |
-+----------+-------------------------------------+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `x`
+  - The first argument.
+
+- - `y`
+  - The second argument, defaults to 1.
+
+:::
+
 ## Value
 
  Returns the sum of `x` and `y`. 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__simple_no_pagetitle.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__simple_no_pagetitle.snap
@@ -22,13 +22,19 @@ simple(x, y = 1)
 
 ## Arguments
 
-+----------+-------------------------------------+
-| Argument | Description                         |
-+==========+=====================================+
-| `x`      | The first argument.                 |
-+----------+-------------------------------------+
-| `y`      | The second argument, defaults to 1. |
-+----------+-------------------------------------+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `x`
+  - The first argument.
+
+- - `y`
+  - The second argument, defaults to 1.
+
+:::
+
 ## Value
 
  Returns the sum of `x` and `y`. 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__simple_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__simple_qmd.snap
@@ -23,13 +23,19 @@ simple(x, y = 1)
 
 ## Arguments
 
-+----------+-------------------------------------+
-| Argument | Description                         |
-+==========+=====================================+
-| `x`      | The first argument.                 |
-+----------+-------------------------------------+
-| `y`      | The second argument, defaults to 1. |
-+----------+-------------------------------------+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `x`
+  - The first argument.
+
+- - `y`
+  - The second argument, defaults to 1.
+
+:::
+
 ## Value
 
  Returns the sum of `x` and `y`. 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__with_links_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__with_links_qmd.snap
@@ -23,11 +23,16 @@ with_links(data)
 
 ## Arguments
 
-+----------+---------------------------------------+
-| Argument | Description                           |
-+==========+=======================================+
-| `data`   | A data frame. See `base::data.frame`. |
-+----------+---------------------------------------+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `data`
+  - A data frame. See `base::data.frame`.
+
+:::
+
 ## See Also
 
 [`simple`](https://rdrr.io/r/base/simple.html), `ggplot2::ggplot`

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -29,10 +29,10 @@ use tabled::settings::style::HorizontalLine;
 pub enum ArgumentsFormat {
     /// Pipe table - limited to inline content in cells
     PipeTable,
-    /// Pandoc grid table (default) - supports block elements (lists, paragraphs) in cells
-    #[default]
+    /// Pandoc grid table - supports block elements (lists, paragraphs) in cells
     GridTable,
-    /// Quarto list-table (`::: {.list-table}`) - requires Quarto 1.9+
+    /// Quarto list-table (`::: {.list-table}`) - requires Quarto 1.9+ (default)
+    #[default]
     ListTable,
 }
 

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -423,7 +423,6 @@ fn convert_single_file(
             exec_donttest: options.exec_donttest,
             quarto_code_blocks: options.quarto_code_blocks,
             arguments_format: options.arguments_format.clone(),
-            ..Default::default()
         };
 
         // Convert to mdast

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -33,8 +33,9 @@ pub enum FallbackReason {
 
 use rayon::prelude::*;
 use rd2qmd_core::{
-    Frontmatter, RdMetadata, RdToMdastOptions, SectionTag, WriterOptions, extract_rd_metadata,
-    extract_text, mdast_to_qmd, parse, parse_roxygen_comments, rd_to_mdast_with_options,
+    ArgumentsFormat, Frontmatter, RdMetadata, RdToMdastOptions, SectionTag, WriterOptions,
+    extract_rd_metadata, extract_text, mdast_to_qmd, parse, parse_roxygen_comments,
+    rd_to_mdast_with_options,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -159,6 +160,8 @@ pub struct PackageConvertOptions {
     /// By default, internal topics are skipped (matching pkgdown behavior).
     /// Set to true to include internal topics in the output.
     pub include_internal: bool,
+    /// Table format for the Arguments section
+    pub arguments_format: ArgumentsFormat,
 }
 
 impl Default for PackageConvertOptions {
@@ -175,6 +178,7 @@ impl Default for PackageConvertOptions {
             exec_dontrun: false,
             exec_donttest: true, // pkgdown-compatible: \donttest{} is executable by default
             include_internal: false, // pkgdown-compatible: skip internal topics by default
+            arguments_format: ArgumentsFormat::default(),
         }
     }
 }
@@ -418,6 +422,7 @@ fn convert_single_file(
             exec_dontrun: options.exec_dontrun,
             exec_donttest: options.exec_donttest,
             quarto_code_blocks: options.quarto_code_blocks,
+            arguments_format: options.arguments_format.clone(),
             ..Default::default()
         };
 
@@ -951,6 +956,7 @@ An old deprecated function.
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1006,6 +1012,7 @@ An old deprecated function.
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1048,6 +1055,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1115,6 +1123,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1162,6 +1171,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1200,6 +1210,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1234,6 +1245,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1286,6 +1298,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false, // Default: skip internal
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();
@@ -1341,6 +1354,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: true, // Include internal topics
+            arguments_format: ArgumentsFormat::default(),
         };
 
         let result = PackageConverter::new(&package, options).convert().unwrap();


### PR DESCRIPTION
## Summary

- Rename `--arguments-table` string values: `"grid"` → `"grid-table"`, `"pipe"` → `"pipe-table"`
- Rename CLI enum variants: `Grid` → `GridTable`, `Pipe` → `PipeTable`
- Change default arguments table format from `grid-table` to `list-table`

## Breaking Changes

- Config files using `arguments_table = "grid"` or `"pipe"` must be updated to `"grid-table"` or `"pipe-table"`
- CLI flag `--arguments-table grid` / `pipe` must be updated accordingly
- Default output changes from grid table to list-table (requires Quarto 1.9+)

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass
- [x] Snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)