### PR TITLE
feat!: rename `--arguments-table` to `--arguments-format` and add list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A fast Rd-to-Quarto Markdown converter written in Rust, with intelligent link re
 - **External package links**: Resolves cross-package links using pkgdown URL conventions (e.g., `\link[dplyr]{mutate}` → `https://dplyr.tidyverse.org/reference/mutate.html`)
 - **Topic index generation**: Outputs JSON index with topic metadata (name, title, aliases, lifecycle) for building reference sites
 - **Quarto-ready**: Generates `.qmd` files with `{r}` executable code blocks and YAML frontmatter
-- **Flexible Arguments tables**: Supports Quarto native List-Tables (default), Pandoc Grid Tables, and GFM Pipe Tables for the Arguments section (`--arguments-table list-table|grid-table|pipe-table`)
+- **Flexible Arguments format**: Supports Quarto native List-Tables (default), Pandoc Grid Tables, GFM Pipe Tables, and Markdown loose lists for the Arguments section (`--arguments-format list-table|grid-table|pipe-table|list`)
 - **pkgdown-compatible metadata**: Adds `pagetitle` in pkgdown style (`"<title> — <name>"`) for SEO
 - **No R required**: Pure Rust binary with no runtime R dependency
 
@@ -78,7 +78,7 @@ rd2qmd man/ -o docs/ -j4
 | `--no-frontmatter` | Disable YAML frontmatter |
 | `--no-pagetitle` | Skip pkgdown-style `pagetitle` metadata (`"<title> — <name>"`) |
 | `--quarto-code-blocks <BOOL>` | Use `{r}` code blocks (auto-set based on format) |
-| `--arguments-table <FORMAT>` | Arguments table format: `list-table` (default), `grid-table`, or `pipe-table` |
+| `--arguments-format <FORMAT>` | Arguments format: `list-table` (default), `grid-table`, `pipe-table`, or `list` |
 | `-v, --verbose` | Verbose output |
 | `-q, --quiet` | Only show errors |
 
@@ -173,16 +173,16 @@ Use `-f md` for standard markdown with:
 - Plain `r` code blocks (non-executable)
 - Internal links resolved to `.md` files
 
-### Arguments table format
+### Arguments format
 
-The Arguments section is rendered as a table. Rd argument descriptions can contain rich content such as lists and multiple paragraphs — `pipe-table` cannot fully represent this and flattens it with `<br>`. Use `--arguments-table` to select the format based on your target renderer:
+The Arguments section is rendered using `--arguments-format`. Rd argument descriptions can contain rich content such as lists and multiple paragraphs — `pipe-table` cannot fully represent this and flattens it with `<br>`. Use `--arguments-format` to select the format based on your target renderer:
 
-| | `list-table` (default) | `grid-table` | `pipe-table` |
-|---|---|---|---|
-| Quarto 1.9+ | ✅ | ✅ | ✅ |
-| Quarto 2 (q2) | ✅ | ❌ | ✅ |
-| Plain Pandoc / Quarto < 1.9 | ❌ | ✅ | ✅ |
-| GFM / general Markdown | ❌ | ❌ | ✅ |
+| | `list-table` (default) | `grid-table` | `pipe-table` | `list` |
+|---|---|---|---|---|
+| Quarto 1.9+ | ✅ | ✅ | ✅ | ✅ |
+| Quarto 2 (q2) | ✅ | ❌ | ✅ | ✅ |
+| Plain Pandoc / Quarto < 1.9 | ❌ | ✅ | ✅ | ✅ |
+| GFM / general Markdown | ❌ | ❌ | ✅ | ✅ |
 
 **`list-table`** (default) — Quarto native syntax, supports full block elements. Recommended for Quarto 1.9+ and q2 workflows:
 
@@ -226,6 +226,21 @@ The Arguments section is rendered as a table. Rd argument descriptions can conta
 |:---|:---|
 | `x` | A simple description. |
 | `opts` | Available options: <br>- option A <br>- option B |
+```
+
+**`list`** — Markdown loose list with argument names as bold inline code. Supports full block elements and works everywhere (GFM, Pandoc, Quarto):
+
+```markdown
+- **`x`**
+
+  A simple description.
+
+- **`opts`**
+
+  Available options:
+
+  - option A
+  - option B
 ```
 
 ## Examples

--- a/crates/rd-parser/src/parser/node_parsers.rs
+++ b/crates/rd-parser/src/parser/node_parsers.rs
@@ -218,8 +218,9 @@ impl Parser {
             }
         }
 
-        // Flush remaining content
-        if !current_text.is_empty() {
+        // Flush remaining content; trailing whitespace after the last \cr
+        // (e.g. a newline before the closing `}`) must not create a spurious empty row.
+        if !current_text.trim_end().is_empty() {
             current_cell.push(RdNode::Text(current_text));
         }
         if !current_cell.is_empty() {

--- a/crates/rd-parser/src/parser/node_parsers.rs
+++ b/crates/rd-parser/src/parser/node_parsers.rs
@@ -218,9 +218,15 @@ impl Parser {
             }
         }
 
-        // Flush remaining content; trailing whitespace after the last \cr
-        // (e.g. a newline before the closing `}`) must not create a spurious empty row.
-        if !current_text.trim_end().is_empty() {
+        // Flush remaining content. Between rows (after the last \cr, both current_row and
+        // current_cell are empty), skip whitespace-only text to avoid a spurious empty row.
+        // Within a row (current_row already has cells from a trailing \tab), preserve the
+        // text so that the final cell is not silently dropped.
+        if current_row.is_empty() && current_cell.is_empty() {
+            if !current_text.trim_end().is_empty() {
+                current_cell.push(RdNode::Text(current_text));
+            }
+        } else if !current_text.is_empty() {
             current_cell.push(RdNode::Text(current_text));
         }
         if !current_cell.is_empty() {

--- a/crates/rd-parser/src/parser/tests.rs
+++ b/crates/rd-parser/src/parser/tests.rs
@@ -886,8 +886,17 @@ fn test_tabular_trailing_tab_without_cr() {
     if let RdNode::Tabular { alignment, rows } = &content[0] {
         assert_eq!(alignment, "ll");
         assert_eq!(rows.len(), 1, "Expected 1 row, got: {rows:?}");
-        assert_eq!(rows[0].len(), 2, "Expected 2 cells (second is whitespace-only), got: {:?}", rows[0]);
-        assert_eq!(rows[0][1], vec![RdNode::Text(" ".to_string())], "Second cell must preserve the whitespace text");
+        assert_eq!(
+            rows[0].len(),
+            2,
+            "Expected 2 cells (second is whitespace-only), got: {:?}",
+            rows[0]
+        );
+        assert_eq!(
+            rows[0][1],
+            vec![RdNode::Text(" ".to_string())],
+            "Second cell must preserve the whitespace text"
+        );
     } else {
         panic!("Expected Tabular node, got {:?}", content[0]);
     }

--- a/crates/rd-parser/src/parser/tests.rs
+++ b/crates/rd-parser/src/parser/tests.rs
@@ -877,6 +877,21 @@ fn test_tabular_tab_cr_with_empty_brace_terminator() {
     }
 }
 
+/// A row ending with `\tab` but no `\cr` must produce two cells; the trailing
+/// whitespace-only cell must not be silently dropped.
+#[test]
+fn test_tabular_trailing_tab_without_cr() {
+    let doc = parse(r#"\details{\tabular{ll}{a \tab }}"#).unwrap();
+    let content = &doc.sections[0].content;
+    if let RdNode::Tabular { alignment, rows } = &content[0] {
+        assert_eq!(alignment, "ll");
+        assert_eq!(rows.len(), 1, "Expected 1 row, got: {rows:?}");
+        assert_eq!(rows[0].len(), 2, "Expected 2 cells (second is whitespace-only), got: {:?}", rows[0]);
+    } else {
+        panic!("Expected Tabular node, got {:?}", content[0]);
+    }
+}
+
 /// In non-code sections (e.g. `\description{}`), bare `{{...}}` remains
 /// Rd text grouping: the braces are unwrapped and the inner content is kept.
 #[test]

--- a/crates/rd-parser/src/parser/tests.rs
+++ b/crates/rd-parser/src/parser/tests.rs
@@ -887,6 +887,7 @@ fn test_tabular_trailing_tab_without_cr() {
         assert_eq!(alignment, "ll");
         assert_eq!(rows.len(), 1, "Expected 1 row, got: {rows:?}");
         assert_eq!(rows[0].len(), 2, "Expected 2 cells (second is whitespace-only), got: {:?}", rows[0]);
+        assert_eq!(rows[0][1], vec![RdNode::Text(" ".to_string())], "Second cell must preserve the whitespace text");
     } else {
         panic!("Expected Tabular node, got {:?}", content[0]);
     }

--- a/crates/rd-parser/tests/snapshots/parser_snapshots__tables.snap
+++ b/crates/rd-parser/tests/snapshots/parser_snapshots__tables.snap
@@ -98,13 +98,6 @@ expression: ast_json
                     "text": " 123 "
                   }
                 ]
-              ],
-              [
-                [
-                  {
-                    "text": "\n"
-                  }
-                ]
               ]
             ]
           }

--- a/crates/rd2qmd-cli/schema/rd2qmd.schema.json
+++ b/crates/rd2qmd-cli/schema/rd2qmd.schema.json
@@ -22,8 +22,8 @@
     }
   },
   "$defs": {
-    "ArgumentsTableFormat": {
-      "description": "Table format for the Arguments section",
+    "ArgumentsFormat": {
+      "description": "Output format for the Arguments section",
       "oneOf": [
         {
           "description": "Pipe table - limited to inline content",
@@ -39,6 +39,11 @@
           "description": "Quarto list-table (default) - requires Quarto 1.9+, compatible with q2",
           "type": "string",
           "const": "list-table"
+        },
+        {
+          "description": "Markdown loose list - bold inline code name + indented description; compatible everywhere",
+          "type": "string",
+          "const": "list"
         }
       ]
     },
@@ -123,11 +128,11 @@
       "description": "Output format configuration",
       "type": "object",
       "properties": {
-        "arguments_table": {
-          "description": "Table format for Arguments section (default: list-table)",
+        "arguments_format": {
+          "description": "Output format for Arguments section (default: list-table)",
           "anyOf": [
             {
-              "$ref": "#/$defs/ArgumentsTableFormat"
+              "$ref": "#/$defs/ArgumentsFormat"
             },
             {
               "type": "null"

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -7,14 +7,12 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-/// Table format for the Arguments section
-// All current variants end with `Table`, but future formats (e.g. list-based) may not.
-#[allow(clippy::enum_variant_names)]
+/// Output format for the Arguments section
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema, clap::ValueEnum,
 )]
 #[serde(rename_all = "kebab-case")]
-pub enum ArgumentsTableFormat {
+pub enum ArgumentsFormat {
     /// Pipe table - limited to inline content
     PipeTable,
     /// Pandoc grid table - supports block elements (lists, paragraphs) in cells
@@ -22,6 +20,8 @@ pub enum ArgumentsTableFormat {
     /// Quarto list-table (default) - requires Quarto 1.9+, compatible with q2
     #[default]
     ListTable,
+    /// Markdown loose list - bold inline code name + indented description; compatible everywhere
+    List,
 }
 
 /// Default configuration file name (following Quarto's `_quarto.yml` convention)
@@ -61,9 +61,9 @@ pub struct OutputConfig {
     /// Add pkgdown-style pagetitle metadata ("<title> — <name>") (default: true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagetitle: Option<bool>,
-    /// Table format for Arguments section (default: list-table)
+    /// Output format for Arguments section (default: list-table)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub arguments_table: Option<ArgumentsTableFormat>,
+    pub arguments_format: Option<ArgumentsFormat>,
     /// Include topics with \keyword{internal} (default: false)
     /// By default, internal topics are skipped (matching pkgdown behavior).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -75,7 +75,7 @@ impl OutputConfig {
         self.format.is_none()
             && self.frontmatter.is_none()
             && self.pagetitle.is_none()
-            && self.arguments_table.is_none()
+            && self.arguments_format.is_none()
             && self.include_internal.is_none()
     }
 }
@@ -196,7 +196,7 @@ impl Config {
                 format: Some("qmd".to_string()),
                 frontmatter: Some(true),
                 pagetitle: Some(true),
-                arguments_table: Some(ArgumentsTableFormat::ListTable),
+                arguments_format: Some(ArgumentsFormat::ListTable),
                 include_internal: Some(false),
             },
             code: CodeConfig {
@@ -236,7 +236,7 @@ mod tests {
             format = "md"
             frontmatter = false
             pagetitle = true
-            arguments_table = "pipe-table"
+            arguments_format = "pipe-table"
             "#,
         )
         .unwrap();
@@ -245,8 +245,8 @@ mod tests {
         assert_eq!(config.output.frontmatter, Some(false));
         assert_eq!(config.output.pagetitle, Some(true));
         assert_eq!(
-            config.output.arguments_table,
-            Some(ArgumentsTableFormat::PipeTable)
+            config.output.arguments_format,
+            Some(ArgumentsFormat::PipeTable)
         );
     }
 
@@ -319,7 +319,7 @@ mod tests {
             format = "qmd"
             frontmatter = true
             pagetitle = true
-            arguments_table = "grid-table"
+            arguments_format = "grid-table"
 
             [code]
             quarto_code_blocks = true

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -4,7 +4,7 @@ mod config;
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
-use config::{ArgumentsTableFormat, Config};
+use config::{ArgumentsFormat as CliArgumentsFormat, Config};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -144,11 +144,10 @@ struct Cli {
     #[arg(long)]
     include_internal: bool,
 
-    /// Table format for the Arguments section: list-table (Quarto list-table, default), grid-table
-    /// (Pandoc grid table), or pipe-table (GFM pipe table, inline content only).
-    /// List-table and grid-table support block elements (lists, paragraphs) in cells.
+    /// Output format for the Arguments section: list-table (Quarto list-table, default), grid-table
+    /// (Pandoc grid table), pipe-table (GFM pipe table, inline only), or list (Markdown loose list).
     #[arg(long, value_enum)]
-    arguments_table: Option<ArgumentsTableFormat>,
+    arguments_format: Option<CliArgumentsFormat>,
 
     /// Generate topic index JSON file (directory mode only)
     /// Contains topic names, files, titles, aliases, and lifecycle stages
@@ -753,16 +752,17 @@ fn merge_unresolved_link_url(cli: &Cli, config: &Config) -> Option<String> {
     )
 }
 
-/// Merge arguments table format: explicit CLI > config > default (list-table)
+/// Merge arguments format: explicit CLI > config > default (list-table)
 fn merge_arguments_format(cli: &Cli, config: &Config) -> ArgumentsFormat {
     let fmt = cli
-        .arguments_table
-        .or(config.output.arguments_table)
+        .arguments_format
+        .or(config.output.arguments_format)
         .unwrap_or_default();
     match fmt {
-        ArgumentsTableFormat::PipeTable => ArgumentsFormat::PipeTable,
-        ArgumentsTableFormat::GridTable => ArgumentsFormat::GridTable,
-        ArgumentsTableFormat::ListTable => ArgumentsFormat::ListTable,
+        CliArgumentsFormat::PipeTable => ArgumentsFormat::PipeTable,
+        CliArgumentsFormat::GridTable => ArgumentsFormat::GridTable,
+        CliArgumentsFormat::ListTable => ArgumentsFormat::ListTable,
+        CliArgumentsFormat::List => ArgumentsFormat::List,
     }
 }
 
@@ -832,7 +832,7 @@ mod tests {
             exec_dontrun: false,
             no_exec_donttest: false,
             include_internal: false,
-            arguments_table: None,
+            arguments_format: None,
             topic_index: None,
             config: None,
             no_config: false,
@@ -994,7 +994,7 @@ mod tests {
         let cli = default_cli();
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some(ArgumentsTableFormat::PipeTable),
+                arguments_format: Some(CliArgumentsFormat::PipeTable),
                 ..Default::default()
             },
             ..Default::default()
@@ -1008,10 +1008,10 @@ mod tests {
     #[test]
     fn test_merge_arguments_format_cli_overrides() {
         let mut cli = default_cli();
-        cli.arguments_table = Some(ArgumentsTableFormat::PipeTable);
+        cli.arguments_format = Some(CliArgumentsFormat::PipeTable);
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some(ArgumentsTableFormat::GridTable),
+                arguments_format: Some(CliArgumentsFormat::GridTable),
                 ..Default::default()
             },
             ..Default::default()
@@ -1026,15 +1026,15 @@ mod tests {
     #[test]
     fn test_merge_arguments_format_list_table_cli_overrides_config() {
         let mut cli = default_cli();
-        cli.arguments_table = Some(ArgumentsTableFormat::ListTable);
+        cli.arguments_format = Some(CliArgumentsFormat::ListTable);
         let config = Config {
             output: config::OutputConfig {
-                arguments_table: Some(ArgumentsTableFormat::GridTable),
+                arguments_format: Some(CliArgumentsFormat::GridTable),
                 ..Default::default()
             },
             ..Default::default()
         };
-        // Explicit --arguments-table list-table must override config grid-table
+        // Explicit --arguments-format list-table must override config grid-table
         assert_eq!(
             merge_arguments_format(&cli, &config),
             ArgumentsFormat::ListTable

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -145,7 +145,7 @@ fn test_directory_conversion_pipe_table() {
         .arg(&fixtures)
         .arg("-o")
         .arg(&output_dir)
-        .arg("--arguments-table")
+        .arg("--arguments-format")
         .arg("pipe-table")
         .arg("-q")
         .status()
@@ -182,14 +182,20 @@ fn test_init_config() {
 
 #[test]
 fn test_simple_pipe_table() {
-    let output = convert_fixture("simple", &["--arguments-table", "pipe-table"]);
+    let output = convert_fixture("simple", &["--arguments-format", "pipe-table"]);
     insta::assert_snapshot!("simple_pipe_table", output);
 }
 
 #[test]
 fn test_simple_list_table() {
-    let output = convert_fixture("simple", &["--arguments-table", "list-table"]);
+    let output = convert_fixture("simple", &["--arguments-format", "list-table"]);
     insta::assert_snapshot!("simple_list_table", output);
+}
+
+#[test]
+fn test_simple_list() {
+    let output = convert_fixture("simple", &["--arguments-format", "list"]);
+    insta::assert_snapshot!("simple_list", output);
 }
 
 #[test]

--- a/crates/rd2qmd-cli/tests/snapshots/integration__formatting_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__formatting_qmd.snap
@@ -26,7 +26,7 @@ formatting()
  Here is a bullet list: 
 
 - First item 
-- Second item with `code` 
+- Second item with `code`
 - Third item 
 
 And a numbered list: 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_config_toml.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_config_toml.snap
@@ -8,7 +8,7 @@ expression: content
 format = "qmd"
 frontmatter = true
 pagetitle = true
-arguments_table = "list-table"
+arguments_format = "list-table"
 include_internal = false
 
 [code]

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
@@ -26,8 +26,8 @@ expression: schema
     }
   },
   "$defs": {
-    "ArgumentsTableFormat": {
-      "description": "Table format for the Arguments section",
+    "ArgumentsFormat": {
+      "description": "Output format for the Arguments section",
       "oneOf": [
         {
           "description": "Pipe table - limited to inline content",
@@ -43,6 +43,11 @@ expression: schema
           "description": "Quarto list-table (default) - requires Quarto 1.9+, compatible with q2",
           "type": "string",
           "const": "list-table"
+        },
+        {
+          "description": "Markdown loose list - bold inline code name + indented description; compatible everywhere",
+          "type": "string",
+          "const": "list"
         }
       ]
     },
@@ -127,11 +132,11 @@ expression: schema
       "description": "Output format configuration",
       "type": "object",
       "properties": {
-        "arguments_table": {
-          "description": "Table format for Arguments section (default: list-table)",
+        "arguments_format": {
+          "description": "Output format for Arguments section (default: list-table)",
           "anyOf": [
             {
-              "$ref": "#/$defs/ArgumentsTableFormat"
+              "$ref": "#/$defs/ArgumentsFormat"
             },
             {
               "type": "null"

--- a/crates/rd2qmd-cli/tests/snapshots/integration__simple_list.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__simple_list.snap
@@ -1,0 +1,43 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+---
+title: "A Simple Function"
+pagetitle: "A Simple Function — simple"
+aliases:
+  - "simple"
+---
+
+# A Simple Function
+
+## Description
+
+ This is a simple function for testing. 
+
+## Usage
+
+```r
+simple(x, y = 1)
+```
+
+## Arguments
+
+- **`x`**
+
+  The first argument.
+
+- **`y`**
+
+  The second argument, defaults to 1.
+
+## Value
+
+ Returns the sum of `x` and `y`. 
+
+## Examples
+
+```{r}
+simple(1, 2)
+simple(10)
+```

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -535,7 +535,7 @@ impl Converter {
 
             if !desc.is_empty() {
                 output.push('\n');
-                output.push_str("  ");  // indent the first block (render_block_content omits it)
+                output.push_str("  "); // indent the first block (render_block_content omits it)
                 output.push_str(desc);
                 output.push('\n');
             }

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -34,6 +34,9 @@ pub enum ArgumentsFormat {
     /// Quarto list-table (`::: {.list-table}`) - requires Quarto 1.9+ (default)
     #[default]
     ListTable,
+    /// Markdown loose list - bold inline code name + indented description
+    /// Supports block elements; compatible with GFM, Pandoc, and Quarto
+    List,
 }
 
 /// Options for Rd to mdast conversion
@@ -358,6 +361,7 @@ impl Converter {
             ArgumentsFormat::PipeTable => self.convert_arguments_pipe(content),
             ArgumentsFormat::GridTable => self.convert_arguments_grid(content),
             ArgumentsFormat::ListTable => self.convert_arguments_list_table(content),
+            ArgumentsFormat::List => self.convert_arguments_list(content),
         }
     }
 
@@ -496,6 +500,50 @@ impl Converter {
         vec![Node::Html(Html { value: output })]
     }
 
+    /// Convert arguments to Markdown loose list format.
+    /// Each argument is a list item with the name as bold inline code and the
+    /// description indented as continuation content (supports block elements).
+    /// Compatible with GFM, Pandoc, and Quarto.
+    fn convert_arguments_list(&mut self, content: &[RdNode]) -> Vec<Node> {
+        let mut items: Vec<(String, String)> = Vec::new();
+
+        for node in content {
+            if let RdNode::Item { label, content } = node
+                && let Some(label_nodes) = label
+            {
+                let term_text = self.extract_text(label_nodes);
+                let arg_code = rd2qmd_mdast::format_inline_code(term_text.trim(), false);
+                let desc_nodes = self.convert_content(content);
+                let desc_text = self.render_block_content(&desc_nodes, 2);
+                items.push((arg_code, desc_text));
+            }
+        }
+
+        if items.is_empty() {
+            return self.convert_content(content);
+        }
+
+        let mut output = String::new();
+
+        for (i, (arg, desc)) in items.iter().enumerate() {
+            if i > 0 {
+                output.push('\n');
+            }
+            output.push_str("- **");
+            output.push_str(arg);
+            output.push_str("**\n");
+
+            if !desc.is_empty() {
+                output.push('\n');
+                output.push_str("  ");  // indent the first block (render_block_content omits it)
+                output.push_str(desc);
+                output.push('\n');
+            }
+        }
+
+        vec![Node::Html(Html { value: output })]
+    }
+
     /// Render mdast nodes as list-table cell content with proper continuation indentation.
     ///
     /// Works on structured nodes so each type controls its own whitespace: paragraph text
@@ -504,6 +552,19 @@ impl Converter {
     /// inline; subsequent blocks are separated by a blank line and each line is prefixed
     /// with four spaces to satisfy the CommonMark list-continuation rule.
     fn render_list_table_cell(&self, nodes: &[Node]) -> String {
+        self.render_block_content(nodes, 4)
+    }
+
+    /// Render mdast nodes as indented block content for use in list items or table cells.
+    ///
+    /// `indent` is the prefix applied to continuation blocks (e.g. `"    "` for list-table
+    /// cells, `"  "` for loose list items). Paragraph text is left-trimmed to remove
+    /// spurious leading spaces from Rd source indentation after normalization. Code block
+    /// content retains its original indentation. The first block starts inline; subsequent
+    /// blocks are separated by a blank line and prefixed with `indent` spaces.
+    fn render_block_content(&self, nodes: &[Node], indent: u8) -> String {
+        let indent = " ".repeat(indent as usize);
+        let indent = indent.as_str();
         let mut result = String::new();
         let mut first_block = true;
 
@@ -516,12 +577,13 @@ impl Converter {
                         continue;
                     }
                     // Split on embedded newlines (e.g. from \cr → Node::Break) and
-                    // prefix each continuation line so it stays inside the cell.
-                    let indented = indent_cell_continuation(text, "    ");
+                    // prefix each continuation line so it stays inside the block.
+                    let indented = indent_cell_continuation(text, indent);
                     if first_block {
                         result.push_str(&indented);
                     } else {
-                        result.push_str("\n\n    ");
+                        result.push_str("\n\n");
+                        result.push_str(indent);
                         result.push_str(&indented);
                     }
                     first_block = false;
@@ -535,15 +597,13 @@ impl Converter {
                             } else {
                                 "- ".to_string()
                             };
-                            // j==0 in first_block has no outer cell prefix; all other
-                            // items are indented 4 spaces (either non-first-block or
-                            // subsequent items within first_block).
-                            let outer: &str = if !first_block || j > 0 { "    " } else { "" };
-                            // Continuation always uses the full cell indent (4 spaces)
-                            // plus marker width, even for j==0 in first_block. Without
-                            // this, a \cr continuation in a list-only cell would render
-                            // as "  - text" — matching the Quarto cell-marker pattern.
-                            let continuation = format!("    {}", " ".repeat(marker.len()));
+                            // j==0 in first_block has no outer prefix; all other items
+                            // are indented (either non-first-block or subsequent items).
+                            let outer: &str = if !first_block || j > 0 { indent } else { "" };
+                            // Continuation always uses the full indent plus marker width,
+                            // even for j==0 in first_block. Without this, a \cr
+                            // continuation in a list-only cell would render incorrectly.
+                            let continuation = format!("{}{}", indent, " ".repeat(marker.len()));
 
                             let item_content = li
                                 .children
@@ -584,9 +644,10 @@ impl Converter {
                     let lang = c.lang.as_deref().unwrap_or("");
                     let fence = code_fence(&c.value);
                     // A fenced code block must start at a line boundary; it cannot be
-                    // placed inline after the "  - " cell marker. Always use a blank
-                    // line + 4-space indent, even when this is the first block.
-                    result.push_str("\n\n    ");
+                    // placed inline after a cell/item marker. Always use a blank line +
+                    // indent, even when this is the first block.
+                    result.push_str("\n\n");
+                    result.push_str(indent);
                     result.push_str(&fence);
                     result.push_str(lang);
                     let lines: Vec<&str> = c.value.split('\n').collect();
@@ -598,12 +659,12 @@ impl Converter {
                     for line in code_lines {
                         result.push('\n');
                         if !line.is_empty() {
-                            result.push_str("    ");
+                            result.push_str(indent);
                             result.push_str(line);
                         }
                     }
                     result.push('\n');
-                    result.push_str("    ");
+                    result.push_str(indent);
                     result.push_str(&fence);
                     first_block = false;
                 }
@@ -616,7 +677,8 @@ impl Converter {
                         if first_block {
                             result.push_str(text);
                         } else {
-                            result.push_str("\n\n    ");
+                            result.push_str("\n\n");
+                            result.push_str(indent);
                             result.push_str(text);
                         }
                         first_block = false;

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -605,10 +605,12 @@ impl Converter {
                             // continuation in a list-only cell would render incorrectly.
                             let continuation = format!("{}{}", indent, " ".repeat(marker.len()));
 
-                            let item_content = li
+                            // First child: inline paragraph content, possibly with \cr
+                            // continuations that need escaping via indent_cell_continuation.
+                            let first_child_text = li
                                 .children
-                                .iter()
-                                .find_map(|c| {
+                                .first()
+                                .and_then(|c| {
                                     if let Node::Paragraph(p) = c {
                                         Some(p)
                                     } else {
@@ -632,8 +634,28 @@ impl Converter {
                             }
                             result.push_str(outer);
                             result.push_str(&marker);
-                            result.push_str(&item_content);
+                            result.push_str(&first_child_text);
                             any_item = true;
+
+                            // Additional children (second paragraph, nested list, code
+                            // block, table, etc.) that the first-child-only path dropped.
+                            for child in li.children.iter().skip(1) {
+                                let text = self.node_to_markdown_string(child);
+                                if text.is_empty() {
+                                    continue;
+                                }
+                                result.push_str("\n\n");
+                                result.push_str(&continuation);
+                                for (i, line) in text.split('\n').enumerate() {
+                                    if i > 0 {
+                                        result.push('\n');
+                                        if !line.is_empty() {
+                                            result.push_str(&continuation);
+                                        }
+                                    }
+                                    result.push_str(line);
+                                }
+                            }
                         }
                     }
                     if any_item {
@@ -1272,17 +1294,13 @@ impl Converter {
         }
     }
 
-    fn convert_list(&self, items: &[RdNode], ordered: bool) -> Node {
+    fn convert_list(&mut self, items: &[RdNode], ordered: bool) -> Node {
         let list_items: Vec<Node> = items
             .iter()
             .filter_map(|item| {
                 if let RdNode::Item { content, .. } = item {
-                    let children = self.convert_inline_nodes(content);
-                    Some(Node::list_item(if children.is_empty() {
-                        vec![]
-                    } else {
-                        vec![Node::paragraph(children)]
-                    }))
+                    let children = self.convert_content(content);
+                    Some(Node::list_item(children))
                 } else {
                     None
                 }

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -607,23 +607,24 @@ impl Converter {
 
                             // First child: inline paragraph content, possibly with \cr
                             // continuations that need escaping via indent_cell_continuation.
-                            let first_child_text = li
+                            // If the first child is not a paragraph (e.g. \tabular{},
+                            // \preformatted{}), treat it as a block child instead so it
+                            // is not silently dropped by the skip(1) below.
+                            let (first_child_text, first_was_para) = li
                                 .children
                                 .first()
-                                .and_then(|c| {
+                                .map(|c| {
                                     if let Node::Paragraph(p) = c {
-                                        Some(p)
+                                        let text = indent_cell_continuation(
+                                            &self.inline_nodes_to_markdown(&p.children),
+                                            &continuation,
+                                        );
+                                        (text, true)
                                     } else {
-                                        None
+                                        (String::new(), false)
                                     }
                                 })
-                                .map(|p| {
-                                    indent_cell_continuation(
-                                        &self.inline_nodes_to_markdown(&p.children),
-                                        &continuation,
-                                    )
-                                })
-                                .unwrap_or_default();
+                                .unwrap_or((String::new(), false));
 
                             if !any_item {
                                 if !first_block {
@@ -638,8 +639,10 @@ impl Converter {
                             any_item = true;
 
                             // Additional children (second paragraph, nested list, code
-                            // block, table, etc.) that the first-child-only path dropped.
-                            for child in li.children.iter().skip(1) {
+                            // block, table, etc.). When the first child was not a paragraph
+                            // it was not consumed above, so start from index 0.
+                            let skip_n = usize::from(first_was_para);
+                            for child in li.children.iter().skip(skip_n) {
                                 let text = self.node_to_markdown_string(child);
                                 if text.is_empty() {
                                     continue;

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -18,7 +18,7 @@ use rd_parser::{
 };
 use rd2qmd_mdast::{
     Align, DefinitionDescription, DefinitionList, DefinitionTerm, Html, Image, Node, Root, Table,
-    TableCell, TableRow,
+    TableCell, TableRow, WriterOptions, mdast_to_qmd,
 };
 use std::collections::HashMap;
 use tabled::settings::Style;
@@ -668,6 +668,25 @@ impl Converter {
                     result.push_str(&fence);
                     first_block = false;
                 }
+                Node::DefinitionList(_) | Node::Table(_) => {
+                    let text = self.node_to_markdown_string(node);
+                    if text.is_empty() {
+                        continue;
+                    }
+                    // Block elements always need a blank line before them
+                    result.push_str("\n\n");
+                    result.push_str(indent);
+                    for (i, line) in text.split('\n').enumerate() {
+                        if i > 0 {
+                            result.push('\n');
+                            if !line.is_empty() {
+                                result.push_str(indent);
+                            }
+                        }
+                        result.push_str(line);
+                    }
+                    first_block = false;
+                }
                 _ => {
                     if let Some(text) = self.node_to_text(node) {
                         let text = text.trim_start();
@@ -688,6 +707,16 @@ impl Converter {
         }
 
         result
+    }
+
+    /// Serialize a single mdast node to a Markdown string via the main writer.
+    fn node_to_markdown_string(&self, node: &Node) -> String {
+        let root = Root::new(vec![node.clone()]);
+        let options = WriterOptions {
+            frontmatter: None,
+            quarto_code_blocks: self.options.quarto_code_blocks,
+        };
+        mdast_to_qmd(&root, &options).trim().to_string()
     }
 
     /// Convert RdNode content to Markdown text for use in grid table cells.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_basic.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_basic.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`x`**
+
+  The first argument.
+
+- **`y`**
+
+  The second argument, defaults to 1.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_item_with_multi_paragraph.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_item_with_multi_paragraph.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`x`**
+
+  Options: 
+
+  - First paragraph.
+
+    Second paragraph of this item.
+  - Another item.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_list_only_description.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_list_only_description.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`method`**
+
+  - `"a"`: Use method A. 
+  - `"b"`: Use method B.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_multi_paragraph.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_multi_paragraph.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`x`**
+
+  First paragraph.
+
+  Second paragraph of the description.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_table_item_with_multi_paragraph.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_table_item_with_multi_paragraph.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `x`
+  - Options: 
+
+    - First paragraph.
+
+      Second paragraph of this item.
+    - Another item. 
+
+:::

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_table_with_describe.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_table_with_describe.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `method`
+  - The method to use: 
+
+    "a"
+    :   Use method A.
+
+    "b"
+    :   Use method B.
+
+:::

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_table_with_tabular.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_table_with_tabular.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+::: {.list-table header-rows=1}
+
+- - Argument
+  - Description
+
+- - `x`
+  - The argument. See the table: 
+
+    |  Col1  |  Col2  |
+    |:---|:---|
+    |  a  |  1  |
+    |  b  |  2  |
+
+:::

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_with_describe.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_with_describe.snap
@@ -1,0 +1,17 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`method`**
+
+  The method to use: 
+
+  "a"
+  :   Use method A.
+
+  "b"
+  :   Use method B.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_with_nested_list.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_with_nested_list.snap
@@ -1,0 +1,20 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`x`**
+
+  A basic argument.
+
+- **`method`**
+
+  The method to use: 
+
+  - `"a"`: Use method A, the default. 
+  - `"b"`: Use method B. 
+
+  Additional details after the list.

--- a/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_with_tabular.snap
+++ b/crates/rd2qmd-core/src/convert/snapshots/rd2qmd_core__convert__tests__arguments_list_with_tabular.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rd2qmd-core/src/convert/tests.rs
+expression: qmd
+---
+# Test
+
+## Arguments
+
+- **`x`**
+
+  The argument. See the table: 
+
+  |  Col1  |  Col2  |
+  |:---|:---|
+  |  a  |  1  |
+  |  b  |  2  |

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -2307,6 +2307,12 @@ fn test_arguments_list_item_starting_with_block() {
     let mdast = rd_to_mdast_with_options(&doc, &options);
     let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
     // The preformatted block must not be dropped
-    assert!(qmd.contains("some_code()"), "preformatted block was dropped; got: {qmd}");
-    assert!(qmd.contains("Normal item."), "second item was dropped; got: {qmd}");
+    assert!(
+        qmd.contains("some_code()"),
+        "preformatted block was dropped; got: {qmd}"
+    );
+    assert!(
+        qmd.contains("Normal item."),
+        "second item was dropped; got: {qmd}"
+    );
 }

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -2033,3 +2033,93 @@ fn test_arguments_list_table_label_with_backticks() {
     let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
     insta::assert_snapshot!(qmd);
 }
+
+#[test]
+fn test_arguments_list_basic() {
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{The first argument.}
+  \item{y}{The second argument, defaults to 1.}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}
+
+#[test]
+fn test_arguments_list_with_nested_list() {
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{A basic argument.}
+  \item{method}{The method to use:
+\itemize{
+\item \code{"a"}: Use method A, the default.
+\item \code{"b"}: Use method B.
+}
+
+Additional details after the list.}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}
+
+#[test]
+fn test_arguments_list_list_only_description() {
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{method}{
+\itemize{
+\item \code{"a"}: Use method A.
+\item \code{"b"}: Use method B.
+}}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}
+
+#[test]
+fn test_arguments_list_multi_paragraph() {
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{First paragraph.
+
+  Second paragraph of the description.}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -2123,3 +2123,55 @@ fn test_arguments_list_multi_paragraph() {
     let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
     insta::assert_snapshot!(qmd);
 }
+
+#[test]
+fn test_arguments_list_with_describe() {
+    // \describe{} in an item description produces a DefinitionList node;
+    // render_block_content must not silently drop it.
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{method}{The method to use:
+\describe{
+\item{"a"}{Use method A.}
+\item{"b"}{Use method B.}
+}
+}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}
+
+#[test]
+fn test_arguments_list_table_with_describe() {
+    // Same as above but for list-table format, verifying render_block_content
+    // handles DefinitionList consistently across both formats.
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{method}{The method to use:
+\describe{
+\item{"a"}{Use method A.}
+\item{"b"}{Use method B.}
+}
+}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::ListTable,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -2175,3 +2175,57 @@ fn test_arguments_list_table_with_describe() {
     let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
     insta::assert_snapshot!(qmd);
 }
+
+#[test]
+fn test_arguments_list_with_tabular() {
+    // \tabular{} in an item description produces a Table node;
+    // render_block_content must not silently drop it.
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{The argument. See the table:
+\tabular{ll}{
+  Col1 \tab Col2 \cr
+  a \tab 1 \cr
+  b \tab 2 \cr
+}
+}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}
+
+#[test]
+fn test_arguments_list_table_with_tabular() {
+    // Same as above but for list-table format, verifying render_block_content
+    // handles Table consistently across both formats.
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{The argument. See the table:
+\tabular{ll}{
+  Col1 \tab Col2 \cr
+  a \tab 1 \cr
+  b \tab 2 \cr
+}
+}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::ListTable,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -2282,3 +2282,31 @@ Second paragraph of this item.
     let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
     insta::assert_snapshot!(qmd);
 }
+
+#[test]
+fn test_arguments_list_item_starting_with_block() {
+    // A nested \itemize inside an argument description where the first (and only)
+    // child of a list item is a block node (\preformatted{}) rather than a
+    // paragraph. Previously render_block_content would drop it via skip(1).
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{Options:
+\itemize{
+\item \preformatted{some_code()}
+\item Normal item.
+}}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    // The preformatted block must not be dropped
+    assert!(qmd.contains("some_code()"), "preformatted block was dropped; got: {qmd}");
+    assert!(qmd.contains("Normal item."), "second item was dropped; got: {qmd}");
+}

--- a/crates/rd2qmd-core/src/convert/tests.rs
+++ b/crates/rd2qmd-core/src/convert/tests.rs
@@ -2229,3 +2229,56 @@ fn test_arguments_list_table_with_tabular() {
     let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
     insta::assert_snapshot!(qmd);
 }
+
+#[test]
+fn test_arguments_list_item_with_multi_paragraph() {
+    // A list item description that contains multiple paragraphs; the second
+    // paragraph must not be silently dropped.
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{Options:
+\itemize{
+\item First paragraph.
+
+Second paragraph of this item.
+\item Another item.
+}}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::List,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}
+
+#[test]
+fn test_arguments_list_table_item_with_multi_paragraph() {
+    // Same as above but for list-table format.
+    let rd = r#"
+\name{test}
+\title{Test}
+\arguments{
+  \item{x}{Options:
+\itemize{
+\item First paragraph.
+
+Second paragraph of this item.
+\item Another item.
+}}
+}
+"#;
+    let doc = parse(rd).unwrap();
+    let options = RdToMdastOptions {
+        arguments_format: ArgumentsFormat::ListTable,
+        ..Default::default()
+    };
+    let mdast = rd_to_mdast_with_options(&doc, &options);
+    let qmd = mdast_to_qmd(&mdast, &rd2qmd_mdast::WriterOptions::default());
+    insta::assert_snapshot!(qmd);
+}

--- a/crates/rd2qmd-mdast/src/writer.rs
+++ b/crates/rd2qmd-mdast/src/writer.rs
@@ -218,6 +218,15 @@ impl<'a> Writer<'a> {
 
     fn write_list_at_indent(&mut self, l: &crate::mdast::List, base_indent: usize) {
         self.ensure_newline();
+        // A list is "loose" when any item contains more than one block child.
+        // Loose lists require blank lines between items and between blocks within an item.
+        let is_loose = l.children.iter().any(|child| {
+            if let Node::ListItem(li) = child {
+                li.children.len() > 1
+            } else {
+                false
+            }
+        });
         let mut num = l.start.unwrap_or(1);
         for child in &l.children {
             if let Node::ListItem(li) = child {
@@ -237,7 +246,8 @@ impl<'a> Writer<'a> {
                     match item_child {
                         Node::Paragraph(p) => {
                             if i > 0 {
-                                // Subsequent paragraphs need indent
+                                // Subsequent paragraphs in a loose item need a blank line
+                                self.output.push('\n');
                                 self.output.push('\n');
                                 for _ in 0..item_indent {
                                     self.output.push(' ');
@@ -250,11 +260,18 @@ impl<'a> Writer<'a> {
                         Node::List(nested) => {
                             // Nested list - write with increased indent
                             self.output.push('\n');
+                            if is_loose {
+                                self.output.push('\n');
+                                for _ in 0..item_indent {
+                                    self.output.push(' ');
+                                }
+                            }
                             self.write_list_at_indent(nested, item_indent);
                             continue; // Skip the newline at the end since nested list handles it
                         }
                         _ => {
                             if i > 0 {
+                                self.output.push('\n');
                                 self.output.push('\n');
                                 for _ in 0..item_indent {
                                     self.output.push(' ');
@@ -265,6 +282,9 @@ impl<'a> Writer<'a> {
                     }
                 }
                 self.output.push('\n');
+                if is_loose {
+                    self.output.push('\n');
+                }
             }
         }
         self.at_line_start = true;
@@ -894,6 +914,31 @@ mod tests {
         let qmd = mdast_to_qmd(&root, &WriterOptions::default());
         assert!(qmd.contains("- Parent"));
         assert!(qmd.contains("  - Child"));
+    }
+
+    #[test]
+    fn test_loose_list_multi_paragraph() {
+        let root = Root::new(vec![Node::list(
+            false,
+            vec![
+                Node::list_item(vec![
+                    Node::paragraph(vec![Node::text("First paragraph")]),
+                    Node::paragraph(vec![Node::text("Second paragraph")]),
+                ]),
+                Node::list_item(vec![Node::paragraph(vec![Node::text("Another item")])]),
+            ],
+        )]);
+        let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+        // Blank line between paragraphs within the same item
+        assert!(
+            qmd.contains("- First paragraph\n\n  Second paragraph"),
+            "got: {qmd:?}"
+        );
+        // Blank line between items in a loose list
+        assert!(
+            qmd.contains("Second paragraph\n\n- Another item"),
+            "got: {qmd:?}"
+        );
     }
 
     #[test]

--- a/crates/rd2qmd-mdast/src/writer.rs
+++ b/crates/rd2qmd-mdast/src/writer.rs
@@ -234,14 +234,19 @@ impl<'a> Writer<'a> {
                 for _ in 0..base_indent {
                     self.output.push(' ');
                 }
-                if l.ordered {
-                    self.output.push_str(&format!("{}. ", num));
+                // Build the marker first so item_indent matches the actual marker width.
+                // "- " is always 2 chars, but "10. " is 4 — a fixed +2 would mis-indent
+                // continuation lines for ordered lists with wide numbers.
+                let marker = if l.ordered {
+                    let m = format!("{}. ", num);
                     num += 1;
+                    m
                 } else {
-                    self.output.push_str("- ");
-                }
+                    "- ".to_string()
+                };
+                self.output.push_str(&marker);
+                let item_indent = base_indent + marker.len();
 
-                let item_indent = base_indent + 2;
                 for (i, item_child) in li.children.iter().enumerate() {
                     match item_child {
                         Node::Paragraph(p) => {
@@ -258,26 +263,38 @@ impl<'a> Writer<'a> {
                             }
                         }
                         Node::List(nested) => {
-                            // Nested list - write with increased indent
+                            // Nested list - write with increased indent.
+                            // Do not manually pre-indent here; write_list_at_indent already
+                            // emits base_indent spaces per item, so pre-indenting would double it.
                             self.output.push('\n');
                             if is_loose {
                                 self.output.push('\n');
-                                for _ in 0..item_indent {
-                                    self.output.push(' ');
-                                }
                             }
                             self.write_list_at_indent(nested, item_indent);
                             continue; // Skip the newline at the end since nested list handles it
                         }
                         _ => {
+                            let indent_str = " ".repeat(item_indent);
                             if i > 0 {
                                 self.output.push('\n');
                                 self.output.push('\n');
-                                for _ in 0..item_indent {
-                                    self.output.push(' ');
-                                }
+                                self.output.push_str(&indent_str);
                             }
+                            // Capture the block output, then re-indent every continuation line
+                            // so multi-line blocks (code fences, tables) stay inside the item.
+                            let start = self.output.len();
                             self.write_node(item_child);
+                            let raw = self.output[start..].to_string();
+                            self.output.truncate(start);
+                            for (j, part) in raw.split('\n').enumerate() {
+                                if j > 0 {
+                                    self.output.push('\n');
+                                    if !part.is_empty() {
+                                        self.output.push_str(&indent_str);
+                                    }
+                                }
+                                self.output.push_str(part);
+                            }
                         }
                     }
                 }
@@ -938,6 +955,65 @@ mod tests {
         assert!(
             qmd.contains("Second paragraph\n\n- Another item"),
             "got: {qmd:?}"
+        );
+    }
+
+    #[test]
+    fn test_ordered_list_loose_continuation_indent() {
+        // "1. " is 3 chars; continuation lines must be indented by 3 spaces, not 2
+        let root = Root::new(vec![Node::list(
+            true,
+            vec![Node::list_item(vec![
+                Node::paragraph(vec![Node::text("First")]),
+                Node::paragraph(vec![Node::text("Second")]),
+            ])],
+        )]);
+        let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+        assert!(
+            qmd.contains("1. First\n\n   Second"),
+            "expected 3-space continuation; got: {qmd:?}"
+        );
+    }
+
+    #[test]
+    fn test_nested_list_not_double_indented() {
+        // Nested item indent must be exactly item_indent (2 for "- "),
+        // not 2 * item_indent (from pre-indent + recursive base_indent).
+        let root = Root::new(vec![Node::list(
+            false,
+            vec![Node::list_item(vec![
+                Node::paragraph(vec![Node::text("Parent")]),
+                Node::list(
+                    false,
+                    vec![Node::list_item(vec![Node::paragraph(vec![Node::text(
+                        "Child",
+                    )])])],
+                ),
+            ])],
+        )]);
+        let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+        assert!(qmd.contains("\n  - Child"), "got: {qmd:?}");
+        assert!(
+            !qmd.contains("    - Child"),
+            "double-indent detected; got: {qmd:?}"
+        );
+    }
+
+    #[test]
+    fn test_loose_list_block_child_continuation_indent() {
+        // All lines of a multi-line block inside a list item must be indented
+        // by item_indent, not just the first line.
+        let root = Root::new(vec![Node::list(
+            false,
+            vec![Node::list_item(vec![
+                Node::paragraph(vec![Node::text("Description:")]),
+                Node::code(Some("r".to_string()), "x <- 1\ny <- 2"),
+            ])],
+        )]);
+        let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+        assert!(
+            qmd.contains("- Description:\n\n  ```r\n  x <- 1\n  y <- 2\n  ```"),
+            "code block continuation lines not indented; got: {qmd:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

### Breaking change

- Rename `--arguments-table` CLI option and `arguments_table` config key to `--arguments-format` / `arguments_format`
- Rename `ArgumentsTableFormat` enum to `ArgumentsFormat`; existing `list-table` value is unchanged

### New feature

- Add `list` format for `--arguments-format`: Markdown loose list where each argument name appears as bold inline code (`` **`arg`** ``), followed by its description as indented block content. Compatible with GFM, Pandoc, and Quarto without any special div syntax.

### Bug fixes

- **`render_block_content`**: `DefinitionList` (`\describe{}`) and `Table` (`\tabular{}`) nodes in argument descriptions were silently dropped; now serialized via `node_to_markdown_string` with correct indentation
- **`rd-parser` / `parse_tabular`**: trailing whitespace after the last `\cr` was creating a spurious empty row; the whitespace-only-skip guard is now narrowed to the between-rows state (both `current_row` and `current_cell` empty), so a trailing `\tab` without `\cr` still preserves the trailing cell
- **`convert_list`**: used `convert_inline_nodes` so block-level nodes inside `\item` (nested `\itemize`, `\preformatted`, `\tabular`, etc.) were silently dropped at the conversion stage; switched to `convert_content`
- **`render_block_content` / `Node::List` arm**: only the first `Paragraph` child of each `ListItem` was rendered; additional children (second paragraph, nested list, code block, table) were dropped; now rendered via `node_to_markdown_string` with continuation-column indentation
- **`render_block_content` / `Node::List` arm**: if the first child of a list item was a block node rather than a paragraph (e.g. a bare `\preformatted{}`), `skip(1)` would drop it; now `skip_n` is 0 in that case so all children go through the block path
- **`write_list_at_indent`**: multi-block list items produced by the updated `convert_list` were rendered with only a single newline between paragraphs, causing Markdown parsers to merge them; now detects loose lists and inserts blank lines between blocks within an item and between items
- **`write_list_at_indent`**: ordered list continuation indent was hardcoded to `+2` regardless of marker width; `"10. "` (4 chars) needs `+4`, not `+2`; now derived from `marker.len()`
- **`write_list_at_indent`**: nested lists inside loose items were pre-indented manually before the recursive call, which also emits `base_indent` spaces per item, doubling the indentation; removed the manual pre-indent
- **`write_list_at_indent`**: non-paragraph block children (code fences, tables) were passed to `write_node` directly, so only the first line landed at the correct column while continuation lines appeared at column zero; now captured and re-indented line-by-line

### Other

- Regenerate `schema/rd2qmd.schema.json` to reflect the renamed field and new variant

## Test plan

- [x] `cargo test --workspace` passes
- [x] Snapshot tests for `list` format: basic, nested list, list-only description, multi-paragraph, `\describe{}`, `\tabular{}`
- [x] Snapshot tests for `list-table` format with `\describe{}` (regression)
- [x] Integration test: `--arguments-format list` produces correct loose list output
- [x] Regression test for `\tabular{}` trailing `\tab` without `\cr`
- [x] Unit tests for multi-paragraph list items in both `list` and `list-table` formats
- [x] Unit test for list item starting with a block node (not dropped)
- [x] Unit test for loose list blank-line rendering in mdast writer
- [x] Unit test for ordered list continuation indent using marker width
- [x] Unit test for nested list not double-indented
- [x] Unit test for code block continuation lines indented inside list item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
