### PR TITLE
fix!: exclude `\if{html}` content from Markdown output by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Default behavior (pkgdown-compatible):
 
 Use `--exec-dontrun` to make `\dontrun{}` code executable, or `--no-exec-donttest` to make `\donttest{}` code non-executable.
 
+### HTML conditional content
+
+Rd files use `\if{html}{...}` to embed content intended only for HTML renderers (CRAN HTML manual, pkgdown, etc.). This often includes raw HTML such as asciicast terminal-output blocks with inline `<span>` styling. By default, rd2qmd **excludes** this content to produce clean Markdown suitable for GitHub, LLMs, and other non-HTML contexts.
+
+Use `--include-html-output` to include `\if{html}{...}` blocks when targeting an HTML-capable renderer such as Quarto HTML output.
+
+`\ifelse{html}{then}{else}` is not affected by this flag — the `then` branch is always used, which preserves lifecycle badges (rendered as Markdown image links) and similar structured content that has a meaningful non-HTML representation.
+
 ## Output formats
 
 ### Quarto Markdown (`.qmd`)

--- a/crates/rd2qmd-cli/examples/benchmark.rs
+++ b/crates/rd2qmd-cli/examples/benchmark.rs
@@ -197,6 +197,7 @@ fn run_single_benchmark(
         exec_dontrun: false,
         exec_donttest: true,     // pkgdown-compatible default
         include_internal: false, // skip internal topics by default
+        include_html_output: false,
         arguments_format: rd2qmd_core::ArgumentsFormat::default(),
     };
 

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -144,6 +144,14 @@ struct Cli {
     #[arg(long)]
     include_internal: bool,
 
+    /// Include \if{html}{...} blocks in the output
+    /// By default, HTML-conditional content is excluded because it targets HTML
+    /// renderers (CRAN HTML manual, pkgdown, etc.) and often contains raw HTML
+    /// markup that produces noise in plain Markdown. Enable when targeting an
+    /// HTML-capable renderer such as Quarto HTML output.
+    #[arg(long)]
+    include_html_output: bool,
+
     /// Output format for the Arguments section: list-table (Quarto list-table, default), grid-table
     /// (Pandoc grid table), pipe-table (GFM pipe table, inline only), or list (Markdown loose list).
     #[arg(long, value_enum)]
@@ -282,6 +290,8 @@ fn main() -> Result<()> {
         config.output.include_internal.unwrap_or(false)
     };
 
+    let include_html_output = cli.include_html_output;
+
     if input.is_file() {
         // Single file conversion (no alias resolution)
         convert_single_file(
@@ -294,6 +304,7 @@ fn main() -> Result<()> {
             unresolved_link_url.as_deref(),
             exec_dontrun,
             exec_donttest,
+            include_html_output,
             arguments_format,
             cli.verbose,
             cli.quiet,
@@ -316,6 +327,7 @@ fn main() -> Result<()> {
             exec_dontrun,
             exec_donttest,
             include_internal,
+            include_html_output,
             arguments_format,
             cli.topic_index.as_deref(),
             cli.verbose,
@@ -341,6 +353,7 @@ fn convert_single_file(
     unresolved_link_url: Option<&str>,
     exec_dontrun: bool,
     exec_donttest: bool,
+    include_html_output: bool,
     arguments_format: ArgumentsFormat,
     verbose: bool,
     quiet: bool,
@@ -369,6 +382,7 @@ fn convert_single_file(
         .quarto_code_blocks(quarto_code_blocks)
         .exec_dontrun(exec_dontrun)
         .exec_donttest(exec_donttest)
+        .include_html_output(include_html_output)
         .arguments_format(arguments_format);
 
     if let Some(url) = unresolved_link_url {
@@ -409,6 +423,7 @@ fn convert_directory(
     exec_dontrun: bool,
     exec_donttest: bool,
     include_internal: bool,
+    include_html_output: bool,
     arguments_format: ArgumentsFormat,
     topic_index_path: Option<&Path>,
     verbose: bool,
@@ -455,6 +470,7 @@ fn convert_directory(
         exec_dontrun,
         exec_donttest,
         include_internal,
+        include_html_output,
         arguments_format,
     };
 
@@ -832,6 +848,7 @@ mod tests {
             exec_dontrun: false,
             no_exec_donttest: false,
             include_internal: false,
+            include_html_output: false,
             arguments_format: None,
             topic_index: None,
             config: None,

--- a/crates/rd2qmd-cli/tests/fixtures/conditionals.Rd
+++ b/crates/rd2qmd-cli/tests/fixtures/conditionals.Rd
@@ -1,0 +1,23 @@
+% Rd file demonstrating \if{html} / \ifelse{} handling
+% Models patterns found in cli-style roxygen2 documentation
+\name{conditionals}
+\alias{conditionals}
+\title{Conditional Examples}
+\description{
+Lifecycle badge: \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+
+Conditional content for different output formats.
+
+HTML only text: \if{html}{This appears in HTML renderers only.}
+
+Text only: \if{text}{This appears in plain text output.}
+}
+\details{
+Example with asciicast output (cli-style):
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{example_function("hello")
+}\if{html}{\out{</div>}}\if{html}{\out{
+<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
+#> <span style="color: #859900;">✔</span> Done: <span style="font-style: italic;">hello</span>
+</pre></div>
+}}
+}

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -113,7 +113,10 @@ fn test_conditionals_default() {
 /// \if{html} is included when --include-html-output is set
 #[test]
 fn test_conditionals_include_html() {
-    let output = convert_fixture("conditionals", &["--no-frontmatter", "--include-html-output"]);
+    let output = convert_fixture(
+        "conditionals",
+        &["--no-frontmatter", "--include-html-output"],
+    );
     insta::assert_snapshot!("conditionals_include_html", output);
 }
 

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -103,6 +103,20 @@ fn test_examplesif_md() {
     insta::assert_snapshot!("examplesif_md", output);
 }
 
+/// \if{html} is excluded by default; \ifelse{html} (lifecycle badge) always renders
+#[test]
+fn test_conditionals_default() {
+    let output = convert_fixture("conditionals", &["--no-frontmatter"]);
+    insta::assert_snapshot!("conditionals_default", output);
+}
+
+/// \if{html} is included when --include-html-output is set
+#[test]
+fn test_conditionals_include_html() {
+    let output = convert_fixture("conditionals", &["--no-frontmatter", "--include-html-output"]);
+    insta::assert_snapshot!("conditionals_include_html", output);
+}
+
 #[test]
 fn test_directory_conversion() {
     let fixtures = fixtures_dir();

--- a/crates/rd2qmd-cli/tests/snapshots/integration__conditionals_default.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__conditionals_default.snap
@@ -1,0 +1,23 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+# Conditional Examples
+
+## Description
+
+ Lifecycle badge: [![[Stable]](lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
+
+Conditional content for different output formats.
+
+HTML only text: 
+
+Text only: This appears in plain text output.
+
+## Details
+
+ Example with asciicast output (cli-style): 
+
+```r
+example_function("hello")
+```

--- a/crates/rd2qmd-cli/tests/snapshots/integration__conditionals_include_html.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__conditionals_include_html.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+# Conditional Examples
+
+## Description
+
+ Lifecycle badge: [![[Stable]](lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
+
+Conditional content for different output formats.
+
+HTML only text: This appears in HTML renderers only.
+
+Text only: This appears in plain text output.
+
+## Details
+
+ Example with asciicast output (cli-style): 
+
+```r
+example_function("hello")
+```
+
+
+<div class="asciicast" style="color: #172431;font-family: 'Fira Code',Monaco,Consolas,Menlo,'Bitstream Vera Sans Mono','Powerline Symbols',monospace;line-height: 1.300000"><pre>
+#> <span style="color: #859900;">✔</span> Done: <span style="font-style: italic;">hello</span>
+</pre></div>

--- a/crates/rd2qmd-cli/tests/snapshots/integration__directory_files.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__directory_files.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/rd2qmd-cli/tests/integration.rs
-assertion_line: 133
 expression: files
 ---
+- conditionals.qmd
 - example_control.qmd
 - examplesif.qmd
 - formatting.qmd

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -73,6 +73,12 @@ pub struct RdToMdastOptions {
     /// GfmTable (default): GFM pipe table, limited to inline content
     /// GridTable: Pandoc grid table, supports block elements in cells
     pub arguments_format: ArgumentsFormat,
+    /// Include \if{html}{...} content in the output (default: false)
+    /// By default, HTML-conditional blocks are excluded because they target
+    /// HTML renderers (CRAN HTML manual, pkgdown, etc.) and often contain raw
+    /// HTML markup that produces noise in plain Markdown. Set to true when
+    /// targeting an HTML-capable renderer such as Quarto HTML output.
+    pub include_html_output: bool,
 }
 
 impl Default for RdToMdastOptions {
@@ -86,6 +92,7 @@ impl Default for RdToMdastOptions {
             exec_donttest: true, // pkgdown-compatible: \donttest{} is executable by default
             quarto_code_blocks: true,
             arguments_format: ArgumentsFormat::default(),
+            include_html_output: false,
         }
     }
 }
@@ -1240,8 +1247,9 @@ impl Converter {
                 Some(Node::inline_code(text))
             }
             RdNode::If { format, content } => {
-                // For markdown/html output, include content if format matches
-                if format == "html" || format == "text" {
+                let include = format == "text"
+                    || (format == "html" && self.options.include_html_output);
+                if include {
                     let inline = self.convert_inline_nodes(content);
                     if inline.len() == 1 {
                         inline.into_iter().next()

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -1247,8 +1247,8 @@ impl Converter {
                 Some(Node::inline_code(text))
             }
             RdNode::If { format, content } => {
-                let include = format == "text"
-                    || (format == "html" && self.options.include_html_output);
+                let include =
+                    format == "text" || (format == "html" && self.options.include_html_output);
                 if include {
                     let inline = self.convert_inline_nodes(content);
                     if inline.len() == 1 {

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -149,6 +149,8 @@ pub struct RdConvertOptions {
     pub links: LinkOptions,
     /// Arguments section table format
     pub arguments_format: ArgumentsFormat,
+    /// Include \if{html}{...} content in the output (default: false)
+    pub include_html_output: bool,
 }
 
 // ============================================================================
@@ -398,6 +400,12 @@ impl RdConverter {
         self
     }
 
+    /// Include \if{html}{...} blocks in the output (default: false)
+    pub fn include_html_output(mut self, enabled: bool) -> Self {
+        self.options.include_html_output = enabled;
+        self
+    }
+
     /// Set all options at once
     pub fn with_options(mut self, options: RdConvertOptions) -> Self {
         self.options = options;
@@ -455,6 +463,7 @@ pub fn convert_rd_content(
         exec_donttest: options.code.exec_donttest,
         quarto_code_blocks: options.code.quarto_code_blocks,
         arguments_format: options.arguments_format.clone(),
+        include_html_output: options.include_html_output,
     };
 
     // Convert to mdast

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -879,6 +879,7 @@ Sys.sleep(10)
                 external_package_urls: None,
             },
             arguments_format: ArgumentsFormat::PipeTable,
+            include_html_output: false,
         };
 
         let result = RdConverter::new(content)

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -1368,6 +1368,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: true, // Include internal topics
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -160,6 +160,11 @@ pub struct PackageConvertOptions {
     /// By default, internal topics are skipped (matching pkgdown behavior).
     /// Set to true to include internal topics in the output.
     pub include_internal: bool,
+    /// Include \if{html}{...} content in the output (default: false)
+    /// By default, HTML-conditional blocks are excluded because they target
+    /// HTML renderers and often contain raw HTML markup that produces noise in
+    /// plain Markdown. Set to true when targeting an HTML-capable renderer.
+    pub include_html_output: bool,
     /// Table format for the Arguments section
     pub arguments_format: ArgumentsFormat,
 }
@@ -178,6 +183,7 @@ impl Default for PackageConvertOptions {
             exec_dontrun: false,
             exec_donttest: true, // pkgdown-compatible: \donttest{} is executable by default
             include_internal: false, // pkgdown-compatible: skip internal topics by default
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         }
     }
@@ -423,6 +429,7 @@ fn convert_single_file(
             exec_donttest: options.exec_donttest,
             quarto_code_blocks: options.quarto_code_blocks,
             arguments_format: options.arguments_format.clone(),
+            include_html_output: options.include_html_output,
         };
 
         // Convert to mdast
@@ -955,6 +962,7 @@ An old deprecated function.
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1011,6 +1019,7 @@ An old deprecated function.
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1054,6 +1063,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1122,6 +1132,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1170,6 +1181,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1209,6 +1221,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1244,6 +1257,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false,
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1297,6 +1311,7 @@ x <- 1
             exec_dontrun: false,
             exec_donttest: true,
             include_internal: false, // Default: skip internal
+            include_html_output: false,
             arguments_format: ArgumentsFormat::default(),
         };
 


### PR DESCRIPTION
## Summary

- `\if{html}{...}` blocks are now **excluded by default** from Markdown output
- New `--include-html-output` opt-in flag for HTML-capable renderers (e.g. Quarto HTML)
- `\ifelse{html}{then}{else}` behavior is unchanged (lifecycle badges continue to render correctly)

## Background

`\if{html}` targets HTML renderers (CRAN HTML manual, pkgdown, etc.) and often contains raw HTML such as asciicast terminal-output blocks with inline `<span>` styling. This caused massive HTML tag contamination when converting packages like pak or cli to plain Markdown.

The roxygen2 sourceCode block pattern (`\if{html}{\out{<div class="sourceCode r">}}\preformatted{...}\if{html}{\out{</div>}}`) is unaffected — it is consumed by `roxygen_code_block.rs` before the generic `\if` handler is reached.

## Test plan

- [ ] New fixture `conditionals.Rd` models cli-style patterns (sourceCode + asciicast + lifecycle badge)
- [ ] `test_conditionals_default`: verifies `\if{html}` excluded, lifecycle badge rendered, sourceCode block preserved
- [ ] `test_conditionals_include_html`: verifies asciicast block included with flag
- [ ] All 49 tests pass across all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)