### PR TITLE
chore: prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-02
+
+### Changed
+
+- **Breaking:** `\if{html}{...}` blocks are now excluded from Markdown output by default. Use `--include-html-output` to restore the previous behavior for HTML-capable renderers such as Quarto HTML (#35).
+
 ## [0.2.0] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "rd-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "serde",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "insta",
  "rd-parser",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-package"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "r-description",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/rd2qmd-cli"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -43,10 +43,10 @@ url = "2"
 insta = { version = "1", features = ["yaml"] }
 
 # Internal crates
-rd2qmd-mdast = { version = "0.2.0", path = "crates/rd2qmd-mdast" }
-rd-parser = { version = "0.2.0", path = "crates/rd-parser" }
-rd2qmd-core = { version = "0.2.0", path = "crates/rd2qmd-core" }
-rd2qmd-package = { version = "0.2.0", path = "crates/rd2qmd-package" }
+rd2qmd-mdast = { version = "0.3.0", path = "crates/rd2qmd-mdast" }
+rd-parser = { version = "0.3.0", path = "crates/rd-parser" }
+rd2qmd-core = { version = "0.3.0", path = "crates/rd2qmd-core" }
+rd2qmd-package = { version = "0.3.0", path = "crates/rd2qmd-package" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.2.0 to 0.3.0
- Finalize CHANGELOG `[Unreleased]` section as `[0.3.0] - 2026-07-02`

## Changelog

### Changed

- **Breaking:** `\if{html}{...}` blocks are now excluded from Markdown output by default. Use `--include-html-output` to restore the previous behavior for HTML-capable renderers such as Quarto HTML (#35).