### PR TITLE
fix: write links as autolinks when the text equals the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
   External link resolution no longer synthesizes fallback URLs itself; packages it cannot resolve now fall back to `--external-link-url`. Manually specified `links.package_urls` entries take precedence over automatically resolved ones.
 
+- Links whose text equals their URL (e.g. from `\url{}`) are now written as CommonMark autolinks (`<https://example.com>` instead of `[https://example.com](https://example.com)`), so renderers that display link URLs alongside the text no longer show the URL twice.
+
 ## [0.3.0] - 2026-07-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
 name = "rd2qmd-mdast"
 version = "0.3.0"
 dependencies = [
+ "insta",
  "serde",
  "serde_json",
 ]

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -823,6 +823,17 @@ Sys.sleep(10)
     }
 
     #[test]
+    fn test_rd_converter_url_autolink() {
+        let content = r#"\name{refs}
+\title{Refs}
+\description{See \url{https://example.com} and \href{https://example.com}{the site}.}
+"#;
+        // \url is written as an autolink; \href with a distinct text is not
+        let result = RdConverter::new(content).convert().unwrap();
+        insta::assert_snapshot!(result);
+    }
+
+    #[test]
     fn test_rd_converter_external_link_url() {
         let content = r#"\name{wrapper}
 \title{Wrapper}

--- a/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_url_autolink.snap
+++ b/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_url_autolink.snap
@@ -1,0 +1,9 @@
+---
+source: crates/rd2qmd-core/src/lib.rs
+expression: result
+---
+# Refs
+
+## Description
+
+See <https://example.com> and [the site](https://example.com).

--- a/crates/rd2qmd-mdast/Cargo.toml
+++ b/crates/rd2qmd-mdast/Cargo.toml
@@ -15,4 +15,5 @@ categories = ["text-processing"]
 serde = { workspace = true }
 
 [dev-dependencies]
+insta.workspace = true
 serde_json.workspace = true

--- a/crates/rd2qmd-mdast/src/snapshots/rd2qmd_mdast__writer__tests__link_autolink.snap
+++ b/crates/rd2qmd-mdast/src/snapshots/rd2qmd_mdast__writer__tests__link_autolink.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rd2qmd-mdast/src/writer.rs
+expression: qmd
+---
+<https://example.com>
+
+<x-r-help:topic>
+
+[topic.html](topic.html)
+
+[https://example.com/a b](https://example.com/a b)

--- a/crates/rd2qmd-mdast/src/writer.rs
+++ b/crates/rd2qmd-mdast/src/writer.rs
@@ -555,6 +555,18 @@ impl<'a> Writer<'a> {
     }
 
     fn write_link(&mut self, l: &crate::mdast::Link) {
+        // CommonMark autolinks require an absolute URI (with scheme) and
+        // no whitespace or angle brackets
+        if l.title.is_none()
+            && matches!(l.children.as_slice(),
+                [crate::mdast::Node::Text(t)] if t.value == l.url)
+            && is_absolute_uri(&l.url)
+        {
+            self.output.push('<');
+            self.output.push_str(&l.url);
+            self.output.push('>');
+            return;
+        }
         self.output.push('[');
         for child in &l.children {
             self.write_node(child);
@@ -618,6 +630,23 @@ impl<'a> Writer<'a> {
 
 fn escape_yaml_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Whether `s` is a valid CommonMark autolink URI: a scheme
+/// (`[A-Za-z][A-Za-z0-9+.-]{1,31}`) followed by `:` and any characters
+/// other than ASCII control, space, `<`, or `>`.
+fn is_absolute_uri(s: &str) -> bool {
+    let Some((scheme, rest)) = s.split_once(':') else {
+        return false;
+    };
+    (2..=32).contains(&scheme.len())
+        && scheme.starts_with(|c: char| c.is_ascii_alphabetic())
+        && scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+        && !rest
+            .chars()
+            .any(|c| c.is_ascii_control() || matches!(c, ' ' | '<' | '>'))
 }
 
 /// Calculate the minimum fence length needed for a code block.
@@ -838,6 +867,27 @@ mod tests {
         )])]);
         let qmd = mdast_to_qmd(&root, &WriterOptions::default());
         assert!(qmd.contains("[Example](https://example.com)"));
+    }
+
+    #[test]
+    fn test_link_autolink() {
+        // A link whose only child is a text equal to its URL is written as
+        // an autolink, but only when the URL is a valid CommonMark
+        // absolute URI (scheme prefix, no spaces)
+        let cases = [
+            "https://example.com",
+            "x-r-help:topic",
+            "topic.html",
+            "https://example.com/a b",
+        ];
+        let root = Root::new(
+            cases
+                .into_iter()
+                .map(|url| Node::paragraph(vec![Node::link(url, vec![Node::text(url)])]))
+                .collect(),
+        );
+        let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+        insta::assert_snapshot!(qmd);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`\url{https://x}` used to be converted to `[https://x](https://x)`. Renderers that display the link URL alongside the link text (such as terminal pagers) show this as a doubled URL: `https://x (https://x)`.

The mdast writer now emits a CommonMark autolink (`<https://x>`) for any link whose only child is a text node identical to its URL, provided the URL is a valid autolink URI (absolute URI with a scheme, no spaces or angle brackets). Links that don't meet the CommonMark autolink constraints (relative URLs, URLs containing spaces) keep the `[text](url)` form, as do `\href{url}{text}` links with distinct text.

This is semantically identical CommonMark, so downstream rendering of existing documents is unchanged apart from the raw Markdown text.

## Testing

- New writer snapshot test covering the autolink decision (absolute URI, custom scheme, relative URL, URL with space)
- New end-to-end snapshot test for `\url{}` vs `\href{}{}`
- `cargo fmt` / `cargo clippy --workspace --all-targets --all-features` clean; full workspace tests and doctests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
