### PR TITLE
feat: add `--prefer-ascii-math` to prefer text representations of equations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `--prefer-ascii-math` option (config: `output.prefer_ascii_math`) to prefer the plain-text representation of `\eqn{latex}{ascii}` / `\deqn{latex}{ascii}` equations over LaTeX math, for renderers without math support such as terminal pagers. `\eqn` is output as inline code and `\deqn` as a plain code block.
+
 ### Changed
 
 - **Breaking:** Redesign the link resolution options around the two Rd link classes (qualified `\link[pkg]{topic}` and unqualified `\link{topic}`), replacing the previous mechanism-based options:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ Use `--include-html-output` to include `\if{html}{...}` blocks when targeting an
 
 `\ifelse{html}{then}{else}` is not affected by this flag — the `then` branch is always used, which preserves lifecycle badges (rendered as Markdown image links) and similar structured content that has a meaningful non-HTML representation.
 
+### Equations
+
+Rd equations carry an optional second argument with a plain-text representation intended for text terminals — `\eqn{\lambda^x}{lambda^x}` — which R's own text help uses. By default, rd2qmd ignores it and outputs LaTeX math (`$...$` for `\eqn`, `$$...$$` for `\deqn`), which suits math-capable renderers such as Quarto.
+
+Use `--prefer-ascii-math` (config: `output.prefer_ascii_math`) when targeting a renderer without math support, such as a terminal pager. Equations with a non-blank ASCII representation are then output as inline code (`\eqn`) or a plain code block (`\deqn`, preserving the layout of multi-line representations such as matrices). Equations without one (e.g. the one-argument form `\eqn{\lambda}`) fall back to LaTeX math as usual.
+
 ## Output formats
 
 ### Quarto Markdown (`.qmd`)

--- a/crates/rd2qmd-cli/examples/benchmark.rs
+++ b/crates/rd2qmd-cli/examples/benchmark.rs
@@ -200,6 +200,7 @@ fn run_single_benchmark(
         exec_donttest: true,     // pkgdown-compatible default
         include_internal: false, // skip internal topics by default
         include_html_output: false,
+        prefer_ascii_math: false,
         arguments_format: rd2qmd_core::ArgumentsFormat::default(),
     };
 

--- a/crates/rd2qmd-cli/schema/rd2qmd.schema.json
+++ b/crates/rd2qmd-cli/schema/rd2qmd.schema.json
@@ -183,6 +183,13 @@
             "boolean",
             "null"
           ]
+        },
+        "prefer_ascii_math": {
+          "description": "Prefer the ASCII representation of \\eqn{}/\\deqn{} equations over LaTeX\nmath when one is present (default: false). Intended for renderers\nwithout math support, such as terminal pagers.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     }

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -69,6 +69,11 @@ pub struct OutputConfig {
     /// By default, internal topics are skipped (matching pkgdown behavior).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_internal: Option<bool>,
+    /// Prefer the ASCII representation of \eqn{}/\deqn{} equations over LaTeX
+    /// math when one is present (default: false). Intended for renderers
+    /// without math support, such as terminal pagers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prefer_ascii_math: Option<bool>,
 }
 
 impl OutputConfig {
@@ -78,6 +83,7 @@ impl OutputConfig {
             && self.pagetitle.is_none()
             && self.arguments_format.is_none()
             && self.include_internal.is_none()
+            && self.prefer_ascii_math.is_none()
     }
 }
 
@@ -211,6 +217,7 @@ impl Config {
                 pagetitle: Some(true),
                 arguments_format: Some(ArgumentsFormat::ListTable),
                 include_internal: Some(false),
+                prefer_ascii_math: None, // enable for renderers without math support
             },
             code: CodeConfig {
                 quarto_code_blocks: None, // auto-detect

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -176,6 +176,13 @@ struct Cli {
     #[arg(long)]
     include_html_output: bool,
 
+    /// Prefer the ASCII representation of \eqn{}/\deqn{} equations over LaTeX
+    /// math when one is present. Intended for renderers without math support,
+    /// such as terminal pagers: \eqn becomes inline code and \deqn becomes a
+    /// plain code block.
+    #[arg(long)]
+    prefer_ascii_math: bool,
+
     /// Output format for the Arguments section: list-table (Quarto list-table, default), grid-table
     /// (Pandoc grid table), pipe-table (GFM pipe table, inline only), or list (Markdown loose list).
     #[arg(long, value_enum)]
@@ -320,6 +327,13 @@ fn main() -> Result<()> {
 
     let include_html_output = cli.include_html_output;
 
+    // prefer_ascii_math: CLI > Config > false (LaTeX math by default)
+    let prefer_ascii_math = if cli.prefer_ascii_math {
+        true
+    } else {
+        config.output.prefer_ascii_math.unwrap_or(false)
+    };
+
     if input.is_file() {
         // Single file conversion (no alias resolution)
         convert_single_file(
@@ -335,6 +349,7 @@ fn main() -> Result<()> {
             exec_dontrun,
             exec_donttest,
             include_html_output,
+            prefer_ascii_math,
             arguments_format,
             cli.verbose,
             cli.quiet,
@@ -361,6 +376,7 @@ fn main() -> Result<()> {
             exec_donttest,
             include_internal,
             include_html_output,
+            prefer_ascii_math,
             arguments_format,
             cli.topic_index.as_deref(),
             cli.verbose,
@@ -389,6 +405,7 @@ fn convert_single_file(
     exec_dontrun: bool,
     exec_donttest: bool,
     include_html_output: bool,
+    prefer_ascii_math: bool,
     arguments_format: ArgumentsFormat,
     verbose: bool,
     quiet: bool,
@@ -417,6 +434,7 @@ fn convert_single_file(
         .exec_dontrun(exec_dontrun)
         .exec_donttest(exec_donttest)
         .include_html_output(include_html_output)
+        .prefer_ascii_math(prefer_ascii_math)
         .arguments_format(arguments_format);
 
     if let Some(template) = unqualified_link_url {
@@ -469,6 +487,7 @@ fn convert_directory(
     exec_donttest: bool,
     include_internal: bool,
     include_html_output: bool,
+    prefer_ascii_math: bool,
     arguments_format: ArgumentsFormat,
     topic_index_path: Option<&Path>,
     verbose: bool,
@@ -520,6 +539,7 @@ fn convert_directory(
         exec_donttest,
         include_internal,
         include_html_output,
+        prefer_ascii_math,
         arguments_format,
     };
 
@@ -904,6 +924,7 @@ mod tests {
             no_exec_donttest: false,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: None,
             topic_index: None,
             config: None,

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
@@ -187,6 +187,13 @@ expression: schema
             "boolean",
             "null"
           ]
+        },
+        "prefer_ascii_math": {
+          "description": "Prefer the ASCII representation of \\eqn{}/\\deqn{} equations over LaTeX\nmath when one is present (default: false). Intended for renderers\nwithout math support, such as terminal pagers.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     }

--- a/crates/rd2qmd-core/src/convert.rs
+++ b/crates/rd2qmd-core/src/convert.rs
@@ -100,6 +100,14 @@ pub struct RdToMdastOptions {
     /// HTML markup that produces noise in plain Markdown. Set to true when
     /// targeting an HTML-capable renderer such as Quarto HTML output.
     pub include_html_output: bool,
+    /// Prefer the ASCII representation of equations (default: false)
+    /// `\eqn{latex}{ascii}` and `\deqn{latex}{ascii}` carry an optional
+    /// second argument meant for text terminals (R's own text help uses it).
+    /// When true, equations with a non-blank ASCII representation are output
+    /// as inline code (`\eqn`) or a plain code block (`\deqn`) instead of
+    /// `$...$` / `$$...$$` math. Intended for renderers without math support,
+    /// such as terminal pagers.
+    pub prefer_ascii_math: bool,
 }
 
 impl Default for RdToMdastOptions {
@@ -115,6 +123,7 @@ impl Default for RdToMdastOptions {
             quarto_code_blocks: true,
             arguments_format: ArgumentsFormat::default(),
             include_html_output: false,
+            prefer_ascii_math: false,
         }
     }
 }
@@ -1042,9 +1051,14 @@ impl Converter {
                     self.flush_paragraph(&mut current_para, &mut result);
                     result.push(Node::code(None, code.clone()));
                 }
-                RdNode::Deqn { latex, ascii: _ } => {
+                RdNode::Deqn { latex, ascii } => {
                     self.flush_paragraph(&mut current_para, &mut result);
-                    result.push(Node::math(latex.clone()));
+                    // A plain code block preserves the layout of multi-line
+                    // ASCII representations (matrices etc.)
+                    result.push(match self.ascii_math(ascii) {
+                        Some(ascii) => Node::code(None, ascii.to_string()),
+                        None => Node::math(latex.clone()),
+                    });
                 }
 
                 // Inline nodes accumulate in current paragraph
@@ -1077,6 +1091,16 @@ impl Converter {
         if !para.is_empty() {
             result.push(Node::paragraph(std::mem::take(para)));
         }
+    }
+
+    /// The ASCII representation of an equation, if `prefer_ascii_math` is
+    /// enabled and one is present. A blank second argument (`\eqn{x}{}`) is
+    /// treated as absent.
+    fn ascii_math<'b>(&self, ascii: &'b Option<String>) -> Option<&'b str> {
+        if !self.options.prefer_ascii_math {
+            return None;
+        }
+        ascii.as_deref().filter(|ascii| !ascii.trim().is_empty())
     }
 
     fn convert_inline_nodes(&self, nodes: &[RdNode]) -> Vec<Node> {
@@ -1226,7 +1250,14 @@ impl Converter {
                 Some(Node::inline_code(text))
             }
             RdNode::Var(name) => Some(Node::emphasis(vec![Node::text(name.clone())])),
-            RdNode::Eqn { latex, ascii: _ } => Some(Node::inline_math(latex.clone())),
+            // Inline code protects Markdown metacharacters (*, _, ^) in the
+            // ASCII representation
+            RdNode::Eqn { latex, ascii } => Some(match self.ascii_math(ascii) {
+                Some(ascii) => {
+                    Node::inline_code(ascii.split_whitespace().collect::<Vec<_>>().join(" "))
+                }
+                None => Node::inline_math(latex.clone()),
+            }),
             RdNode::Special(ch) => Some(Node::text(special_char_to_string(*ch))),
             RdNode::LineBreak => Some(Node::Break),
             RdNode::Samp(children) => {

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -167,6 +167,9 @@ pub struct RdConvertOptions {
     pub arguments_format: ArgumentsFormat,
     /// Include \if{html}{...} content in the output (default: false)
     pub include_html_output: bool,
+    /// Prefer the ASCII representation of `\eqn`/`\deqn` equations over
+    /// LaTeX math when one is present (default: false)
+    pub prefer_ascii_math: bool,
 }
 
 // ============================================================================
@@ -432,6 +435,13 @@ impl RdConverter {
         self
     }
 
+    /// Prefer the ASCII representation of `\eqn`/`\deqn` equations over
+    /// LaTeX math when one is present (default: false)
+    pub fn prefer_ascii_math(mut self, enabled: bool) -> Self {
+        self.options.prefer_ascii_math = enabled;
+        self
+    }
+
     /// Set all options at once
     pub fn with_options(mut self, options: RdConvertOptions) -> Self {
         self.options = options;
@@ -491,6 +501,7 @@ pub fn convert_rd_content(
         quarto_code_blocks: options.code.quarto_code_blocks,
         arguments_format: options.arguments_format.clone(),
         include_html_output: options.include_html_output,
+        prefer_ascii_math: options.prefer_ascii_math,
     };
 
     // Convert to mdast
@@ -822,6 +833,36 @@ Sys.sleep(10)
         insta::assert_snapshot!(result);
     }
 
+    const MATH_RD: &str = r#"\name{poisson}
+\title{Poisson}
+\description{
+The density is
+\deqn{p(x) = \frac{\lambda^x e^{-\lambda}}{x!}}{p(x) = lambda^x
+exp(-lambda) / x!}
+for \eqn{x = 0, 1, 2, \ldots}{x = 0, 1, 2, ...}. The mean is
+\eqn{\lambda} and \eqn{E(X)}{} equals it.
+}
+"#;
+
+    #[test]
+    fn test_rd_converter_math_default() {
+        // Default: LaTeX math output, ASCII representations are ignored
+        let result = RdConverter::new(MATH_RD).convert().unwrap();
+        insta::assert_snapshot!(result);
+    }
+
+    #[test]
+    fn test_rd_converter_prefer_ascii_math() {
+        // \deqn becomes a plain code block, \eqn becomes inline code with
+        // whitespace normalized; equations without a non-blank ASCII
+        // representation (one-arg form, empty second arg) stay LaTeX math
+        let result = RdConverter::new(MATH_RD)
+            .prefer_ascii_math(true)
+            .convert()
+            .unwrap();
+        insta::assert_snapshot!(result);
+    }
+
     #[test]
     fn test_rd_converter_url_autolink() {
         let content = r#"\name{refs}
@@ -992,6 +1033,7 @@ Sys.sleep(10)
             },
             arguments_format: ArgumentsFormat::PipeTable,
             include_html_output: false,
+            prefer_ascii_math: false,
         };
 
         let result = RdConverter::new(content)

--- a/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_math_default.snap
+++ b/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_math_default.snap
@@ -1,0 +1,15 @@
+---
+source: crates/rd2qmd-core/src/lib.rs
+expression: result
+---
+# Poisson
+
+## Description
+
+ The density is 
+
+$$
+p(x) = \frac{\lambda^x e^{-\lambda}}{x!}
+$$
+
+ for $x = 0, 1, 2, \ldots$. The mean is $\lambda$and $E(X)$ equals it.

--- a/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_prefer_ascii_math.snap
+++ b/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_prefer_ascii_math.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rd2qmd-core/src/lib.rs
+expression: result
+---
+# Poisson
+
+## Description
+
+ The density is 
+
+```
+p(x) = lambda^x
+exp(-lambda) / x!
+```
+
+ for `x = 0, 1, 2, ...`. The mean is $\lambda$and $E(X)$ equals it.

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -178,6 +178,9 @@ pub struct PackageConvertOptions {
     /// HTML renderers and often contain raw HTML markup that produces noise in
     /// plain Markdown. Set to true when targeting an HTML-capable renderer.
     pub include_html_output: bool,
+    /// Prefer the ASCII representation of `\eqn`/`\deqn` equations over
+    /// LaTeX math when one is present (default: false)
+    pub prefer_ascii_math: bool,
     /// Table format for the Arguments section
     pub arguments_format: ArgumentsFormat,
 }
@@ -199,6 +202,7 @@ impl Default for PackageConvertOptions {
             exec_donttest: true, // pkgdown-compatible: \donttest{} is executable by default
             include_internal: false, // pkgdown-compatible: skip internal topics by default
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         }
     }
@@ -451,6 +455,7 @@ fn convert_single_file(
             quarto_code_blocks: options.quarto_code_blocks,
             arguments_format: options.arguments_format.clone(),
             include_html_output: options.include_html_output,
+            prefer_ascii_math: options.prefer_ascii_math,
         };
 
         // Convert to mdast
@@ -999,6 +1004,7 @@ An old deprecated function.
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1058,6 +1064,7 @@ An old deprecated function.
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1104,6 +1111,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1175,6 +1183,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1216,6 +1225,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1270,6 +1280,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1452,6 +1463,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1490,6 +1502,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false,
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1546,6 +1559,7 @@ x <- 1
             exec_donttest: true,
             include_internal: false, // Default: skip internal
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 
@@ -1605,6 +1619,7 @@ x <- 1
             exec_donttest: true,
             include_internal: true, // Include internal topics
             include_html_output: false,
+            prefer_ascii_math: false,
             arguments_format: ArgumentsFormat::default(),
         };
 


### PR DESCRIPTION
## Summary

The second argument of `\eqn{latex}{ascii}` / `\deqn{latex}{ascii}` is a plain-text representation intended for text terminals — R's own text help uses it. rd2qmd discarded it and always emitted LaTeX math (`$...$` / `$$...$$`), which is hard to read in renderers without math support, such as terminal pagers.

This PR adds an opt-in `--prefer-ascii-math` flag (config: `output.prefer_ascii_math`, library: `RdConverter::prefer_ascii_math` / `PackageConvertOptions::prefer_ascii_math`). When enabled and the equation has a non-blank ASCII representation:

- `\eqn` → inline code. Plain text was rejected because the writer does not escape Text nodes, so Markdown metacharacters in the ASCII form (`*`, `_`, and `^` — superscript in Quarto) would corrupt the equation. Whitespace (including newlines from source wrapping) is normalized to single spaces.
- `\deqn` → plain fenced code block, preserving the layout of multi-line representations such as matrices byte-for-byte.

Equations without an ASCII representation — the one-argument form and a blank second argument (`\eqn{x}{}`) — keep the LaTeX output. Default behavior is unchanged.

## Testing

- Snapshot tests: default (LaTeX) and `prefer_ascii_math` outputs for the same Rd covering `\deqn` with a multi-line ASCII form, `\eqn` with ASCII, the one-argument form, and an empty second argument
- JSON schema snapshot updated; schema file regenerated
- E2E verified all three paths: default, `--prefer-ascii-math`, and `output.prefer_ascii_math = true` in `_rd2qmd.toml`
- `cargo fmt` / `cargo clippy --workspace --all-targets --all-features` clean; full workspace tests and doctests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
