### PR TITLE
fix: preserve whitespace after optional-arg macros when second arg is absent

### DIFF
--- a/crates/rd-parser/src/parser/node_parsers.rs
+++ b/crates/rd-parser/src/parser/node_parsers.rs
@@ -274,6 +274,7 @@ impl Parser {
         self.expect(&TokenKind::CloseBrace)?;
 
         // Parse the fallback argument
+        let pos_before_whitespace = self.pos;
         self.skip_whitespace();
         let fallback = if self.check(&TokenKind::OpenBrace) {
             self.expect(&TokenKind::OpenBrace)?;
@@ -281,7 +282,9 @@ impl Parser {
             self.expect(&TokenKind::CloseBrace)?;
             fb
         } else {
-            // If no fallback provided, use encoded as fallback
+            // No fallback provided; restore the whitespace we skipped so it's
+            // preserved in the surrounding text, and use encoded as fallback.
+            self.pos = pos_before_whitespace;
             encoded.clone()
         };
 
@@ -336,6 +339,7 @@ impl Parser {
         self.expect(&TokenKind::CloseBrace)?;
 
         // Optional ASCII alternative
+        let pos_before_whitespace = self.pos;
         self.skip_whitespace();
         let ascii = if self.check(&TokenKind::OpenBrace) {
             self.advance();
@@ -343,6 +347,9 @@ impl Parser {
             self.expect(&TokenKind::CloseBrace)?;
             Some(ascii)
         } else {
+            // No second argument; restore the whitespace we skipped so it's
+            // preserved in the surrounding text.
+            self.pos = pos_before_whitespace;
             None
         };
 
@@ -475,6 +482,7 @@ impl Parser {
         self.expect(&TokenKind::CloseBrace)?;
 
         // Check for optional second brace argument (options)
+        let pos_before_whitespace = self.pos;
         self.skip_whitespace();
         let raw_options = if self.check(&TokenKind::OpenBrace) {
             self.advance(); // consume {
@@ -482,6 +490,9 @@ impl Parser {
             self.expect(&TokenKind::CloseBrace)?;
             Some(opts)
         } else {
+            // No second argument; restore the whitespace we skipped so it's
+            // preserved in the surrounding text.
+            self.pos = pos_before_whitespace;
             opt_arg // Fallback to bracket arg if provided
         };
 

--- a/crates/rd-parser/src/parser/node_parsers.rs
+++ b/crates/rd-parser/src/parser/node_parsers.rs
@@ -265,7 +265,7 @@ impl Parser {
         Ok(Some(RdNode::Href { url, text }))
     }
 
-    /// Parse \enc{encoded}{fallback}
+    /// Parse \enc{encoded}{fallback} or \enc{encoded} (fallback defaults to encoded)
     /// Preserves both arguments in AST for format-specific output selection
     pub(super) fn parse_enc(&mut self) -> ParseResult<Option<RdNode>> {
         self.skip_whitespace();
@@ -331,7 +331,7 @@ impl Parser {
             .unwrap_or_default()
     }
 
-    /// Parse \eqn{latex}{ascii} or \deqn{latex}{ascii}
+    /// Parse \eqn{latex}{ascii} or \deqn{latex}{ascii}; the `{ascii}` argument is optional
     pub(super) fn parse_equation(&mut self, display: bool) -> ParseResult<Option<RdNode>> {
         self.skip_whitespace();
         self.expect(&TokenKind::OpenBrace)?;

--- a/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_math_default.snap
+++ b/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_math_default.snap
@@ -12,4 +12,4 @@ $$
 p(x) = \frac{\lambda^x e^{-\lambda}}{x!}
 $$
 
- for $x = 0, 1, 2, \ldots$. The mean is $\lambda$and $E(X)$ equals it.
+ for $x = 0, 1, 2, \ldots$. The mean is $\lambda$ and $E(X)$ equals it.

--- a/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_prefer_ascii_math.snap
+++ b/crates/rd2qmd-core/src/snapshots/rd2qmd_core__tests__rd_converter_prefer_ascii_math.snap
@@ -13,4 +13,4 @@ p(x) = lambda^x
 exp(-lambda) / x!
 ```
 
- for `x = 0, 1, 2, ...`. The mean is $\lambda$and $E(X)$ equals it.
+ for `x = 0, 1, 2, ...`. The mean is $\lambda$ and $E(X)$ equals it.


### PR DESCRIPTION
## Summary
- `parse_equation` (`\eqn`/`\deqn`), `parse_figure`, and `parse_enc` all speculatively skip whitespace to look ahead for an optional second brace argument, but never restored the parser position when that argument was absent — dropping the whitespace between the macro and any following text (e.g. `\eqn{x} text` rendered as `$x$text`).
- Save the position before the speculative skip and restore it when no second argument is found, in all three parsers.
- Updated the `rd2qmd-core` snapshots (`rd_converter_math_default`, `rd_converter_prefer_ascii_math`) affected by the fix.

## Test plan
- [x] `cargo test --workspace --all-features --all-targets`
- [x] `cargo clippy --workspace --all-targets --all-features`