### PR TITLE
feat: add AST JSON I/O (`parse` subcommand and `--input-format`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Add a `parse` subcommand that parses Rd files (single file or directory) to AST JSON instead of converting them directly, so external tooling can inspect or rewrite the parsed document before running `convert`. The output is a versioned envelope (`{"version": 1, "source": ..., "sourceFiles": ..., "document": ...}`) around an output-format-independent AST — links keep their raw Rd semantics, with URL resolution and `.qmd`/`.md` extensions applied only at conversion time.
+- Add `--input-format <rd|ast>` to `convert` and `index` to read AST JSON produced by `parse` instead of `.Rd` files (a `.json` input is auto-detected in single-file mode without the flag). Directory-mode features such as alias/internal-link resolution work identically with AST input.
 - Add `--prefer-ascii-math` option (config: `output.prefer_ascii_math`) to prefer the plain-text representation of `\eqn{latex}{ascii}` / `\deqn{latex}{ascii}` equations over LaTeX math, for renderers without math support such as terminal pagers. `\eqn` is output as inline code and `\deqn` as a plain code block.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/eitsupi/rd2qmd/rel
 
 ## Usage
 
-rd2qmd provides three subcommands:
+rd2qmd provides four subcommands:
 
 - `convert` — convert Rd files to Quarto Markdown, R Markdown, or standard Markdown
+- `parse` — parse Rd files to AST JSON (see [AST JSON I/O](#ast-json-io))
 - `index` — generate a JSON topic index (see [Topic index generation](#topic-index-generation))
 - `init` — create a starter `_rd2qmd.toml` configuration file
 
@@ -87,6 +88,7 @@ rd2qmd convert man/ -o docs/ -j4
 | `--no-pagetitle` | Skip pkgdown-style `pagetitle` metadata (`"<title> — <name>"`) |
 | `--quarto-code-blocks <BOOL>` | Use `{r}` code blocks (auto-set based on format) |
 | `--arguments-format <FORMAT>` | Arguments format: `list-table` (default), `grid-table`, `pipe-table`, or `list` |
+| `--input-format <FORMAT>` | Input format: `rd` (default) or `ast` (see [AST JSON I/O](#ast-json-io)) |
 | `-v, --verbose` | Verbose output |
 | `-q, --quiet` | Only show errors |
 
@@ -197,7 +199,12 @@ rd2qmd index man/ | jq '.topics[] | select(.lifecycle)'
 
 # Generate index while converting
 rd2qmd convert man/ -o docs/ --topic-index index.json
+
+# Generate an index from AST JSON produced by `parse`
+rd2qmd index tmp_ast/ --input-format ast
 ```
+
+`index` also accepts `--input-format <rd|ast>` (see [AST JSON I/O](#ast-json-io)) to scan `.json` files instead of `.Rd` files.
 
 The index includes topic name, output file, title, aliases, and lifecycle stage:
 
@@ -216,6 +223,60 @@ The index includes topic name, output file, title, aliases, and lifecycle stage:
 ```
 
 The `lifecycle` field is omitted for topics without a lifecycle badge. Supported stages: `experimental`, `stable`, `superseded`, `deprecated`, and legacy stages (`maturing`, `questioning`, `soft_deprecated`, `defunct`, `retired`).
+
+### AST JSON I/O
+
+The `parse` subcommand parses Rd files into AST JSON instead of converting them directly, letting external tooling inspect or rewrite the parsed document before a later `convert` run turns it into Markdown:
+
+```bash
+# Parse a single file (default output: input stem + .json)
+rd2qmd parse man/foo.Rd -o foo.json
+
+# Parse a directory, one .json per .Rd file
+rd2qmd parse man/ -o ast_dir/ -j4
+```
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <PATH>` | Output file or directory |
+| `-r, --recursive` | Process directories recursively |
+| `-j, --jobs <N>` | Number of parallel jobs (defaults to CPU count) |
+| `-v, --verbose` | Verbose output |
+| `-q, --quiet` | Only show errors |
+
+`parse` has no conversion options (frontmatter, link resolution, etc.) since those apply only when producing Markdown, and it does not read `_rd2qmd.toml`. It also performs no internal-topic filtering — every file is exported, since filtering `\keyword{internal}` topics is the responsibility of the final `convert`/`index` step.
+
+Each output file is an envelope around the parsed document:
+
+```json
+{
+  "version": 1,
+  "source": "foo.Rd",
+  "sourceFiles": ["R/foo.R"],
+  "document": { ... }
+}
+```
+
+- `version` — schema version. Reading a mismatched version is an error.
+- `source` — the original Rd file name, so JSON-processing tools can filter by file.
+- `sourceFiles` — R source files recorded in roxygen2 header comments; metadata about the document, not part of the AST itself.
+- `document` — the parsed Rd document AST.
+
+The AST is output-format-independent: links are stored with their raw Rd semantics (package and topic name), and URL resolution plus the `.qmd`/`.md` extension are only applied when converting. This means a single `parse` run can feed both `qmd` and `md` output later.
+
+The AST JSON structure mirrors rd2qmd's internal types, so producing and consuming it with the same rd2qmd version is recommended; the `version` field guards against mismatches across versions.
+
+One thing to keep in mind when rewriting text nodes: text inside a section (for example `\usage`) can be split across multiple AST text nodes when Rd macros such as `\method{}{}` are present, so simple string replacement across a section's raw text should account for that.
+
+Feed AST JSON back into `convert` (or `index`) with `--input-format ast`; a `.json` input is also auto-detected in single-file mode without the flag:
+
+```bash
+rd2qmd parse man/ -o tmp_ast/
+# rewrite text nodes inside tmp_ast/*.json with any tool/language you like
+rd2qmd convert tmp_ast/ --input-format ast -o docs/man/ --topic-index index.json
+```
+
+Directory-mode features such as alias/internal-link resolution work identically with AST input.
 
 ### Example control options
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Each output file is an envelope around the parsed document:
 ```
 
 - `version` — schema version. Reading a mismatched version is an error.
-- `source` — the original Rd file name, so JSON-processing tools can filter by file.
+- `source` — the original Rd file name, so JSON-processing tools can filter by file. This is informational metadata only: output file names and link targets are derived from the `.json` file names (which `parse` mirrors from the `.Rd` names), so keep the file names unchanged when feeding AST JSON back to `convert`.
 - `sourceFiles` — R source files recorded in roxygen2 header comments; metadata about the document, not part of the AST itself.
 - `document` — the parsed Rd document AST.
 
@@ -276,7 +276,7 @@ rd2qmd parse man/ -o tmp_ast/
 rd2qmd convert tmp_ast/ --input-format ast -o docs/man/ --topic-index index.json
 ```
 
-Directory-mode features such as alias/internal-link resolution work identically with AST input.
+Directory-mode features such as alias/internal-link resolution work identically with AST input, as long as the file names produced by `parse` are kept.
 
 ### Example control options
 

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -55,6 +55,15 @@ enum InputFormat {
     Ast,
 }
 
+impl InputFormat {
+    fn file_extension(self) -> &'static str {
+        match self {
+            Self::Rd => ".Rd",
+            Self::Ast => ".json",
+        }
+    }
+}
+
 impl From<InputFormat> for PackageInputFormat {
     fn from(format: InputFormat) -> Self {
         match format {
@@ -606,7 +615,11 @@ fn convert_directory(
 
     // Load package with alias index
     if verbose {
-        eprintln!("Scanning {} for Rd files...", input.display());
+        eprintln!(
+            "Scanning {} for {} files...",
+            input.display(),
+            input_format.file_extension()
+        );
     }
 
     let package = RdPackage::from_directory_with_format(input, recursive, input_format.into())
@@ -614,13 +627,21 @@ fn convert_directory(
 
     if package.files().is_empty() {
         if !quiet {
-            eprintln!("No .Rd files found in {}", input.display());
+            eprintln!(
+                "No {} files found in {}",
+                input_format.file_extension(),
+                input.display()
+            );
         }
         return Ok(());
     }
 
     if verbose {
-        eprintln!("Found {} .Rd files", package.files().len());
+        eprintln!(
+            "Found {} {} files",
+            package.files().len(),
+            input_format.file_extension()
+        );
         eprintln!(
             "Built alias index with {} entries",
             package.alias_index().len()
@@ -917,7 +938,11 @@ fn run_index_command(args: &IndexArgs) -> Result<()> {
     .with_context(|| format!("Failed to scan directory: {}", args.input.display()))?;
 
     if package.files().is_empty() {
-        anyhow::bail!("No .Rd files found in {}", args.input.display());
+        anyhow::bail!(
+            "No {} files found in {}",
+            args.input_format.file_extension(),
+            args.input.display()
+        );
     }
 
     let index_options = TopicIndexOptions {

--- a/crates/rd2qmd-cli/src/main.rs
+++ b/crates/rd2qmd-cli/src/main.rs
@@ -8,10 +8,14 @@ use config::{ArgumentsFormat as CliArgumentsFormat, Config};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use rd2qmd_core::{ArgumentsFormat, RdConverter};
+use rd2qmd_core::{
+    ArgumentsFormat, CodeExecutionOptions, FrontmatterOptions, LinkOptions, RdAstEnvelope,
+    RdConvertOptions, RdConverter, convert_rd_document, parse, parse_roxygen_comments,
+};
 use rd2qmd_package::{
     ExternalLinkOptions as PackageExternalLinkOptions, FallbackReason, FullConvertResult,
-    PackageConvertOptions, PackageConverter, RdPackage, TopicIndexOptions, generate_topic_index,
+    InputFormat as PackageInputFormat, PackageConvertOptions, PackageConverter, RdPackage,
+    TopicIndexOptions, export_package_ast, generate_topic_index,
 };
 
 /// Default URL template for qualified links (`\link[pkg]{topic}`) whose
@@ -41,6 +45,25 @@ enum OutputFormat {
     Rmd,
 }
 
+/// Input format for Rd documentation
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+enum InputFormat {
+    /// Rd source files (.Rd)
+    #[default]
+    Rd,
+    /// Pre-parsed AST JSON envelopes produced by `rd2qmd parse` (.json)
+    Ast,
+}
+
+impl From<InputFormat> for PackageInputFormat {
+    fn from(format: InputFormat) -> Self {
+        match format {
+            InputFormat::Rd => PackageInputFormat::Rd,
+            InputFormat::Ast => PackageInputFormat::AstJson,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "rd2qmd")]
 #[command(about = "Convert Rd files to Quarto Markdown")]
@@ -54,6 +77,8 @@ enum OutputFormat {
   rd2qmd convert man/ -o docs/              # Convert directory (with alias resolution)
   rd2qmd convert man/ -o docs/ -j4          # Use 4 parallel jobs
   rd2qmd convert man/ --topic-index i.json  # Convert and generate topic index
+  rd2qmd parse man/ -o ast_dir/             # Parse to AST JSON for later convert
+  rd2qmd convert ast_dir/ --input-format ast -o docs/  # Convert AST JSON back
   rd2qmd index man/                 # Generate topic index JSON to stdout
   rd2qmd index man/ | jq '.topics[] | select(.lifecycle)'")]
 struct Cli {
@@ -204,6 +229,11 @@ struct ConvertArgs {
     /// Ignore configuration file
     #[arg(long)]
     no_config: bool,
+
+    /// Input format: rd (default) or ast (pre-parsed AST JSON from `rd2qmd parse`)
+    /// A single-file `.json` input is auto-detected as ast without this flag.
+    #[arg(long, value_enum, default_value_t = InputFormat::Rd)]
+    input_format: InputFormat,
 }
 
 /// Subcommands
@@ -211,6 +241,14 @@ struct ConvertArgs {
 enum Commands {
     /// Convert Rd files to Quarto Markdown (or standard Markdown / R Markdown)
     Convert(Box<ConvertArgs>),
+
+    /// Parse Rd files to AST JSON
+    ///
+    /// Parses Rd files (single file or directory) into a versioned JSON
+    /// envelope around the parsed document, letting external tooling inspect
+    /// or rewrite it before a later `convert` run turns it into Markdown.
+    /// Has no conversion options and does not read `_rd2qmd.toml`.
+    Parse(ParseArgs),
 
     /// Generate topic index JSON to stdout
     ///
@@ -244,6 +282,30 @@ struct IndexArgs {
     /// By default, internal topics are excluded (matching pkgdown behavior).
     #[arg(long)]
     include_internal: bool,
+
+    /// Input format: rd (default) or ast (pre-parsed AST JSON from `rd2qmd parse`)
+    #[arg(long, value_enum, default_value_t = InputFormat::Rd)]
+    input_format: InputFormat,
+}
+
+/// Arguments for the parse subcommand
+#[derive(Args, Debug)]
+struct ParseArgs {
+    /// Input Rd file or directory
+    input: PathBuf,
+
+    /// Output file or directory (default: input stem + .json, or the input
+    /// directory itself in directory mode)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Process directories recursively
+    #[arg(short, long)]
+    recursive: bool,
+
+    /// Number of parallel jobs (defaults to number of CPUs)
+    #[arg(short, long)]
+    jobs: Option<usize>,
 }
 
 /// Arguments for the init subcommand
@@ -267,6 +329,7 @@ fn main() -> Result<()> {
 
     match cli.subcommand {
         Commands::Convert(args) => run_convert_command(&args, cli.verbose, cli.quiet),
+        Commands::Parse(args) => run_parse_command(&args, cli.verbose, cli.quiet),
         Commands::Index(args) => run_index_command(&args),
         Commands::Init(args) => run_init_command(&args, cli.quiet),
     }
@@ -342,6 +405,7 @@ fn run_convert_command(args: &ConvertArgs, verbose: bool, quiet: bool) -> Result
             &input,
             args.output.as_deref(),
             output_extension,
+            args.input_format,
             use_frontmatter,
             use_pagetitle,
             quarto_code_blocks,
@@ -366,6 +430,7 @@ fn run_convert_command(args: &ConvertArgs, verbose: bool, quiet: bool) -> Result
             args.output.as_deref(),
             output_extension,
             args.recursive,
+            args.input_format,
             use_frontmatter,
             use_pagetitle,
             quarto_code_blocks,
@@ -398,6 +463,7 @@ fn convert_single_file(
     input: &Path,
     output: Option<&Path>,
     output_extension: &str,
+    input_format: InputFormat,
     use_frontmatter: bool,
     use_pagetitle: bool,
     quarto_code_blocks: bool,
@@ -425,35 +491,72 @@ fn convert_single_file(
         );
     }
 
-    let content = fs::read_to_string(input)
-        .with_context(|| format!("Failed to read: {}", input.display()))?;
+    let is_ast = input_format == InputFormat::Ast
+        || input
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("json"));
 
-    // Build converter using RdConverter builder pattern
-    let mut converter = RdConverter::new(&content)
-        .frontmatter(use_frontmatter)
-        .pagetitle(use_pagetitle)
-        .quarto_code_blocks(quarto_code_blocks)
-        .exec_dontrun(exec_dontrun)
-        .exec_donttest(exec_donttest)
-        .include_html_output(include_html_output)
-        .prefer_ascii_math(prefer_ascii_math)
-        .arguments_format(arguments_format);
+    let qmd = if is_ast {
+        let content = fs::read_to_string(input)
+            .with_context(|| format!("Failed to read: {}", input.display()))?;
 
-    if let Some(template) = unqualified_link_url {
-        converter = converter.unqualified_link_url(template);
-    }
+        let envelope = RdAstEnvelope::from_json(&content)
+            .with_context(|| format!("Failed to read AST JSON envelope: {}", input.display()))?;
 
-    if let Some(template) = external_link_url {
-        converter = converter.external_link_url(template);
-    }
+        let options = RdConvertOptions {
+            frontmatter: FrontmatterOptions {
+                enabled: use_frontmatter,
+                pagetitle: use_pagetitle,
+            },
+            code: CodeExecutionOptions {
+                quarto_code_blocks,
+                exec_dontrun,
+                exec_donttest,
+            },
+            links: LinkOptions {
+                internal_link_url: None,
+                unqualified_link_url: unqualified_link_url.map(|s| s.to_string()),
+                external_link_url: external_link_url.map(|s| s.to_string()),
+                alias_map: None,
+                package_urls,
+            },
+            arguments_format,
+            include_html_output,
+            prefer_ascii_math,
+        };
 
-    if let Some(urls) = package_urls {
-        converter = converter.package_urls(urls);
-    }
+        convert_rd_document(&envelope.document, envelope.source_files, &options)
+    } else {
+        let content = fs::read_to_string(input)
+            .with_context(|| format!("Failed to read: {}", input.display()))?;
 
-    let qmd = converter
-        .convert()
-        .map_err(|e| anyhow::anyhow!("Parse error: {}", e))?;
+        // Build converter using RdConverter builder pattern
+        let mut converter = RdConverter::new(&content)
+            .frontmatter(use_frontmatter)
+            .pagetitle(use_pagetitle)
+            .quarto_code_blocks(quarto_code_blocks)
+            .exec_dontrun(exec_dontrun)
+            .exec_donttest(exec_donttest)
+            .include_html_output(include_html_output)
+            .prefer_ascii_math(prefer_ascii_math)
+            .arguments_format(arguments_format);
+
+        if let Some(template) = unqualified_link_url {
+            converter = converter.unqualified_link_url(template);
+        }
+
+        if let Some(template) = external_link_url {
+            converter = converter.external_link_url(template);
+        }
+
+        if let Some(urls) = package_urls {
+            converter = converter.package_urls(urls);
+        }
+
+        converter
+            .convert()
+            .map_err(|e| anyhow::anyhow!("Parse error: {}", e))?
+    };
 
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent)
@@ -477,6 +580,7 @@ fn convert_directory(
     output: Option<&Path>,
     output_extension: &str,
     recursive: bool,
+    input_format: InputFormat,
     use_frontmatter: bool,
     use_pagetitle: bool,
     quarto_code_blocks: bool,
@@ -505,7 +609,7 @@ fn convert_directory(
         eprintln!("Scanning {} for Rd files...", input.display());
     }
 
-    let package = RdPackage::from_directory(input, recursive)
+    let package = RdPackage::from_directory_with_format(input, recursive, input_format.into())
         .with_context(|| format!("Failed to scan directory: {}", input.display()))?;
 
     if package.files().is_empty() {
@@ -703,6 +807,96 @@ fn display_fallback_warnings(
     }
 }
 
+/// Run the parse subcommand: parse Rd files to AST JSON
+fn run_parse_command(args: &ParseArgs, verbose: bool, quiet: bool) -> Result<()> {
+    let input = args.input.clone();
+
+    if input.is_file() {
+        parse_single_file(&input, args.output.as_deref(), verbose, quiet)?;
+    } else if input.is_dir() {
+        let output_dir = args.output.clone().unwrap_or_else(|| input.to_path_buf());
+
+        if verbose {
+            eprintln!("Scanning {} for Rd files...", input.display());
+        }
+
+        let result = export_package_ast(&input, args.recursive, &output_dir, args.jobs)
+            .with_context(|| format!("Failed to scan directory: {}", input.display()))?;
+
+        if !quiet {
+            for path in &result.output_files {
+                println!("{}", path.display());
+            }
+        }
+
+        for (file, error) in &result.failed_files {
+            eprintln!("Error parsing {}: {}", file.display(), error);
+        }
+
+        if !quiet {
+            eprintln!(
+                "Parsed {} files, {} failed",
+                result.success_count,
+                result.failed_files.len()
+            );
+        }
+
+        if !result.failed_files.is_empty() {
+            anyhow::bail!("{} files failed to parse", result.failed_files.len());
+        }
+    } else {
+        anyhow::bail!("Input path does not exist: {}", input.display());
+    }
+
+    Ok(())
+}
+
+/// Parse a single Rd file to an AST JSON envelope
+fn parse_single_file(
+    input: &Path,
+    output: Option<&Path>,
+    verbose: bool,
+    quiet: bool,
+) -> Result<()> {
+    let output_path = match output {
+        Some(p) => p.to_path_buf(),
+        None => input.with_extension("json"),
+    };
+
+    if verbose {
+        eprintln!("Parsing: {} -> {}", input.display(), output_path.display());
+    }
+
+    let content = fs::read_to_string(input)
+        .with_context(|| format!("Failed to read: {}", input.display()))?;
+
+    let source_files = parse_roxygen_comments(&content).source_files;
+    let doc = parse(&content).map_err(|e| anyhow::anyhow!("Parse error: {}", e))?;
+
+    let source = input
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string());
+    let envelope = RdAstEnvelope::new(doc, source, source_files);
+    let json = envelope
+        .to_json_pretty()
+        .with_context(|| "Failed to serialize AST JSON")?;
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    fs::write(&output_path, &json)
+        .with_context(|| format!("Failed to write: {}", output_path.display()))?;
+
+    if !quiet {
+        println!("{}", output_path.display());
+    }
+
+    Ok(())
+}
+
 /// Run the index subcommand: generate topic index JSON to stdout
 fn run_index_command(args: &IndexArgs) -> Result<()> {
     if !args.input.is_dir() {
@@ -715,8 +909,12 @@ fn run_index_command(args: &IndexArgs) -> Result<()> {
         OutputFormat::Rmd => "Rmd",
     };
 
-    let package = RdPackage::from_directory(&args.input, args.recursive)
-        .with_context(|| format!("Failed to scan directory: {}", args.input.display()))?;
+    let package = RdPackage::from_directory_with_format(
+        &args.input,
+        args.recursive,
+        args.input_format.into(),
+    )
+    .with_context(|| format!("Failed to scan directory: {}", args.input.display()))?;
 
     if package.files().is_empty() {
         anyhow::bail!("No .Rd files found in {}", args.input.display());
@@ -930,6 +1128,7 @@ mod tests {
             topic_index: None,
             config: None,
             no_config: false,
+            input_format: InputFormat::Rd,
         }
     }
 

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -715,3 +715,41 @@ fn test_parse_defaults_directory() {
 
     assert_eq!(files, expected);
 }
+
+#[test]
+fn test_convert_empty_ast_directory_mentions_json_files() {
+    let root = unique_temp_dir("convert_empty_ast");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let output = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&root)
+        .arg("--input-format")
+        .arg("ast")
+        .output()
+        .expect("Failed to run rd2qmd convert");
+
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("No .json files found"));
+}
+
+#[test]
+fn test_index_empty_ast_directory_mentions_json_files() {
+    let root = unique_temp_dir("index_empty_ast");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let output = Command::new(rd2qmd_binary())
+        .arg("index")
+        .arg(&root)
+        .arg("--input-format")
+        .arg("ast")
+        .output()
+        .expect("Failed to run rd2qmd index");
+
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("No .json files found"));
+}

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -15,6 +15,21 @@ fn rd2qmd_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/rd2qmd")
 }
 
+/// Build a unique temporary directory path for a test (not created)
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let unique_id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "rd2qmd_test_{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        unique_id,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ))
+}
+
 /// Run rd2qmd on a fixture file and return the output
 fn convert_fixture(name: &str, args: &[&str]) -> String {
     let input = fixtures_dir().join(format!("{}.Rd", name));
@@ -359,4 +374,344 @@ fn test_external_links_fallback_warning_no_external_link_url() {
         "external_links_fallback_warning_no_external_link_url",
         stderr
     );
+}
+
+/// `parse` then `convert --input-format ast` produces byte-identical output
+/// to a direct `convert` for a single file
+#[test]
+fn test_parse_convert_roundtrip_single_file() {
+    let direct = convert_fixture("with_links", &[]);
+
+    let root = unique_temp_dir("roundtrip_single");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let json_path = root.join("with_links.json");
+    let status = Command::new(rd2qmd_binary())
+        .arg("parse")
+        .arg(fixtures_dir().join("with_links.Rd"))
+        .arg("-o")
+        .arg(&json_path)
+        .status()
+        .expect("Failed to run rd2qmd parse");
+    assert!(
+        status.success(),
+        "rd2qmd parse failed with status: {}",
+        status
+    );
+
+    let qmd_path = root.join("with_links.qmd");
+    let status = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&json_path)
+        .arg("--input-format")
+        .arg("ast")
+        .arg("-o")
+        .arg(&qmd_path)
+        .status()
+        .expect("Failed to run rd2qmd convert");
+    assert!(
+        status.success(),
+        "rd2qmd convert --input-format ast failed with status: {}",
+        status
+    );
+
+    let via_ast = fs::read_to_string(&qmd_path).expect("Failed to read output file");
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(direct, via_ast);
+}
+
+/// `parse` then `convert --input-format ast` produces byte-identical output
+/// to a direct `convert` for a whole directory
+#[test]
+fn test_parse_convert_roundtrip_directory() {
+    let fixtures = fixtures_dir();
+    let root = unique_temp_dir("roundtrip_dir");
+    let ast_dir = root.join("ast");
+    let out_dir = root.join("out");
+    let direct_dir = root.join("direct");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let status = Command::new(rd2qmd_binary())
+        .arg("parse")
+        .arg(&fixtures)
+        .arg("-o")
+        .arg(&ast_dir)
+        .status()
+        .expect("Failed to run rd2qmd parse");
+    assert!(
+        status.success(),
+        "rd2qmd parse failed with status: {}",
+        status
+    );
+
+    let status = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&ast_dir)
+        .arg("--input-format")
+        .arg("ast")
+        .arg("-o")
+        .arg(&out_dir)
+        .arg("-q")
+        .status()
+        .expect("Failed to run rd2qmd convert");
+    assert!(
+        status.success(),
+        "rd2qmd convert --input-format ast failed with status: {}",
+        status
+    );
+
+    let status = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&fixtures)
+        .arg("-o")
+        .arg(&direct_dir)
+        .arg("-q")
+        .status()
+        .expect("Failed to run rd2qmd convert");
+    assert!(
+        status.success(),
+        "rd2qmd convert failed with status: {}",
+        status
+    );
+
+    let mut direct_files: Vec<_> = fs::read_dir(&direct_dir)
+        .expect("Failed to read direct output dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    direct_files.sort();
+    assert!(!direct_files.is_empty());
+
+    for file in &direct_files {
+        let direct_content =
+            fs::read_to_string(direct_dir.join(file)).expect("Failed to read direct output file");
+        let via_ast_content = fs::read_to_string(out_dir.join(file))
+            .unwrap_or_else(|_| panic!("Missing AST-converted output file: {}", file));
+        assert_eq!(direct_content, via_ast_content, "Mismatch for {}", file);
+    }
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// `sourceFiles` recorded from a roxygen2 header comment survive a
+/// `parse` -> edit -> `convert --input-format ast` round trip and show up in
+/// the output frontmatter, same as a direct convert would produce
+#[test]
+fn test_parse_convert_roundtrip_preserves_source_files() {
+    let root = unique_temp_dir("source_files");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    fs::write(
+        root.join("roundtrip.Rd"),
+        "% Generated by roxygen2: do not edit by hand\n\
+         % Please edit documentation in R/roundtrip.R\n\
+         \\name{roundtrip}\n\
+         \\alias{roundtrip}\n\
+         \\title{Roundtrip}\n\
+         \\description{\nA function for round-trip testing.\n}\n",
+    )
+    .expect("Failed to write Rd fixture");
+
+    let json_path = root.join("roundtrip.json");
+    let status = Command::new(rd2qmd_binary())
+        .arg("parse")
+        .arg(root.join("roundtrip.Rd"))
+        .arg("-o")
+        .arg(&json_path)
+        .status()
+        .expect("Failed to run rd2qmd parse");
+    assert!(
+        status.success(),
+        "rd2qmd parse failed with status: {}",
+        status
+    );
+
+    let json = fs::read_to_string(&json_path).expect("Failed to read AST JSON");
+    assert!(json.contains("\"sourceFiles\""));
+    assert!(json.contains("R/roundtrip.R"));
+
+    let qmd_path = root.join("roundtrip.qmd");
+    let status = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&json_path)
+        .arg("--input-format")
+        .arg("ast")
+        .arg("-o")
+        .arg(&qmd_path)
+        .status()
+        .expect("Failed to run rd2qmd convert");
+    assert!(
+        status.success(),
+        "rd2qmd convert --input-format ast failed with status: {}",
+        status
+    );
+
+    let qmd = fs::read_to_string(&qmd_path).expect("Failed to read output file");
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(qmd.contains("source-files:"));
+    assert!(qmd.contains("R/roundtrip.R"));
+}
+
+/// A hand-written envelope with a mismatched `version` field fails
+/// `convert --input-format ast` with a non-zero exit and a message
+/// mentioning the version
+#[test]
+fn test_convert_ast_version_mismatch() {
+    let root = unique_temp_dir("version_mismatch");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let json_path = root.join("bad.json");
+    fs::write(
+        &json_path,
+        r#"{"version":99,"source":"bad.Rd","sourceFiles":[],"document":{"sections":[]}}"#,
+    )
+    .expect("Failed to write bad envelope");
+
+    let output = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&json_path)
+        .arg("--input-format")
+        .arg("ast")
+        .output()
+        .expect("Failed to run rd2qmd convert");
+
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(
+        !output.status.success(),
+        "rd2qmd convert should fail on a version mismatch"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(
+        stderr.contains("version"),
+        "Expected a version-mismatch message, got: {}",
+        stderr
+    );
+}
+
+/// Parsing, then rewriting a text node inside the AST JSON, then converting
+/// back should surface the rewritten text in the Markdown output -- the
+/// motivating use case for AST JSON I/O
+#[test]
+fn test_parse_edit_convert_pipeline() {
+    let root = unique_temp_dir("pipeline");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let json_path = root.join("with_links.json");
+    let status = Command::new(rd2qmd_binary())
+        .arg("parse")
+        .arg(fixtures_dir().join("with_links.Rd"))
+        .arg("-o")
+        .arg(&json_path)
+        .status()
+        .expect("Failed to run rd2qmd parse");
+    assert!(
+        status.success(),
+        "rd2qmd parse failed with status: {}",
+        status
+    );
+
+    let json = fs::read_to_string(&json_path).expect("Failed to read AST JSON");
+    assert!(json.contains("with_links(data)"));
+    let rewritten = json.replace("with_links(data)", "with_links(data, verbose = TRUE)");
+    fs::write(&json_path, rewritten).expect("Failed to rewrite AST JSON");
+
+    let qmd_path = root.join("with_links.qmd");
+    let status = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(&json_path)
+        .arg("--input-format")
+        .arg("ast")
+        .arg("-o")
+        .arg(&qmd_path)
+        .status()
+        .expect("Failed to run rd2qmd convert");
+    assert!(
+        status.success(),
+        "rd2qmd convert --input-format ast failed with status: {}",
+        status
+    );
+
+    let qmd = fs::read_to_string(&qmd_path).expect("Failed to read output file");
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(qmd.contains("with_links(data, verbose = TRUE)"));
+}
+
+/// Single-file `parse` with no `-o` writes `<stem>.json` next to the input
+#[test]
+fn test_parse_defaults_single_file() {
+    let root = unique_temp_dir("parse_defaults_single");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let input = root.join("simple.Rd");
+    fs::copy(fixtures_dir().join("simple.Rd"), &input).expect("Failed to copy fixture");
+
+    let status = Command::new(rd2qmd_binary())
+        .arg("parse")
+        .arg(&input)
+        .status()
+        .expect("Failed to run rd2qmd parse");
+    assert!(
+        status.success(),
+        "rd2qmd parse failed with status: {}",
+        status
+    );
+
+    let expected_output = root.join("simple.json");
+    assert!(
+        expected_output.exists(),
+        "Expected {} to exist",
+        expected_output.display()
+    );
+    let json = fs::read_to_string(&expected_output).expect("Failed to read AST JSON");
+    let _ = fs::remove_dir_all(&root);
+
+    assert!(json.contains("\"version\": 1"));
+}
+
+/// Directory `parse` mirrors input file names with a `.json` extension
+#[test]
+fn test_parse_defaults_directory() {
+    let fixtures = fixtures_dir();
+    let root = unique_temp_dir("parse_defaults_dir");
+    fs::create_dir_all(&root).expect("Failed to create temp dir");
+
+    let status = Command::new(rd2qmd_binary())
+        .arg("parse")
+        .arg(&fixtures)
+        .arg("-o")
+        .arg(&root)
+        .status()
+        .expect("Failed to run rd2qmd parse");
+    assert!(
+        status.success(),
+        "rd2qmd parse failed with status: {}",
+        status
+    );
+
+    let mut files: Vec<_> = fs::read_dir(&root)
+        .expect("Failed to read output dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    files.sort();
+
+    let mut expected: Vec<_> = fs::read_dir(&fixtures)
+        .expect("Failed to read fixtures dir")
+        .filter_map(|e| e.ok())
+        .map(|e| {
+            PathBuf::from(e.file_name())
+                .with_extension("json")
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect();
+    expected.sort();
+
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(files, expected);
 }

--- a/crates/rd2qmd-core/src/ast_io.rs
+++ b/crates/rd2qmd-core/src/ast_io.rs
@@ -23,7 +23,7 @@ pub enum AstIoError {
     Json(#[from] serde_json::Error),
     /// The envelope's `version` field does not match [`AST_FORMAT_VERSION`]
     #[error("unsupported AST format version: expected {expected}, found {found}")]
-    VersionMismatch { expected: u32, found: u32 },
+    VersionMismatch { expected: u32, found: u64 },
 }
 
 /// A parsed Rd document paired with the metadata needed to convert it later
@@ -63,14 +63,13 @@ impl RdAstEnvelope {
     pub fn from_json(json: &str) -> Result<Self, AstIoError> {
         let value: serde_json::Value = serde_json::from_str(json)?;
 
-        if let Some(found) = value.get("version").and_then(|v| v.as_u64()) {
-            let found = found as u32;
-            if found != AST_FORMAT_VERSION {
-                return Err(AstIoError::VersionMismatch {
-                    expected: AST_FORMAT_VERSION,
-                    found,
-                });
-            }
+        if let Some(found) = value.get("version").and_then(|v| v.as_u64())
+            && found != u64::from(AST_FORMAT_VERSION)
+        {
+            return Err(AstIoError::VersionMismatch {
+                expected: AST_FORMAT_VERSION,
+                found,
+            });
         }
 
         Ok(serde_json::from_value(value)?)
@@ -127,6 +126,20 @@ mod tests {
             AstIoError::VersionMismatch {
                 expected: AST_FORMAT_VERSION,
                 found: 99
+            }
+        ));
+    }
+
+    #[test]
+    fn test_envelope_version_mismatch_beyond_u32() {
+        let json =
+            r#"{"version":4294967297,"source":null,"sourceFiles":[],"document":{"sections":[]}}"#;
+        let err = RdAstEnvelope::from_json(json).unwrap_err();
+        assert!(matches!(
+            err,
+            AstIoError::VersionMismatch {
+                expected: AST_FORMAT_VERSION,
+                found: 4294967297
             }
         ));
     }

--- a/crates/rd2qmd-core/src/ast_io.rs
+++ b/crates/rd2qmd-core/src/ast_io.rs
@@ -1,0 +1,133 @@
+//! JSON envelope for exchanging parsed Rd ASTs between tools
+//!
+//! The envelope wraps a [`RdDocument`] together with the metadata needed to
+//! convert it later without re-reading the original `.Rd` file: the source
+//! file name and the roxygen2-derived `source_files` list (the latter is not
+//! part of the AST itself, since it comes from raw Rd header comments rather
+//! than parsed sections).
+
+use crate::RdDocument;
+use serde::{Deserialize, Serialize};
+
+/// Version of the AST JSON envelope format
+///
+/// Bump this when the envelope shape or [`RdDocument`]'s serialized form
+/// changes in a way that breaks older readers.
+pub const AST_FORMAT_VERSION: u32 = 1;
+
+/// Error type for AST envelope JSON I/O
+#[derive(Debug, thiserror::Error)]
+pub enum AstIoError {
+    /// The JSON could not be parsed or does not match the envelope shape
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    /// The envelope's `version` field does not match [`AST_FORMAT_VERSION`]
+    #[error("unsupported AST format version: expected {expected}, found {found}")]
+    VersionMismatch { expected: u32, found: u32 },
+}
+
+/// A parsed Rd document paired with the metadata needed to convert it later
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RdAstEnvelope {
+    /// AST format version, see [`AST_FORMAT_VERSION`]
+    pub version: u32,
+    /// Original `.Rd` file name (e.g. `"alpha.Rd"`)
+    pub source: Option<String>,
+    /// R source files that generated this Rd file (from roxygen2 comments)
+    pub source_files: Vec<String>,
+    /// The parsed Rd document
+    pub document: RdDocument,
+}
+
+impl RdAstEnvelope {
+    /// Create a new envelope at the current [`AST_FORMAT_VERSION`]
+    pub fn new(document: RdDocument, source: Option<String>, source_files: Vec<String>) -> Self {
+        Self {
+            version: AST_FORMAT_VERSION,
+            source,
+            source_files,
+            document,
+        }
+    }
+
+    /// Serialize the envelope to a pretty-printed JSON string
+    pub fn to_json_pretty(&self) -> Result<String, AstIoError> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    /// Deserialize an envelope from a JSON string
+    ///
+    /// Returns [`AstIoError::VersionMismatch`] if the envelope's `version`
+    /// field does not match [`AST_FORMAT_VERSION`].
+    pub fn from_json(json: &str) -> Result<Self, AstIoError> {
+        let value: serde_json::Value = serde_json::from_str(json)?;
+
+        if let Some(found) = value.get("version").and_then(|v| v.as_u64()) {
+            let found = found as u32;
+            if found != AST_FORMAT_VERSION {
+                return Err(AstIoError::VersionMismatch {
+                    expected: AST_FORMAT_VERSION,
+                    found,
+                });
+            }
+        }
+
+        Ok(serde_json::from_value(value)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RdNode, RdSection, SectionTag};
+
+    fn sample_document() -> RdDocument {
+        RdDocument {
+            sections: vec![RdSection {
+                tag: SectionTag::Name,
+                content: vec![RdNode::Text("foo".to_string())],
+            }],
+        }
+    }
+
+    #[test]
+    fn test_envelope_roundtrip() {
+        let envelope = RdAstEnvelope::new(
+            sample_document(),
+            Some("foo.Rd".to_string()),
+            vec!["R/foo.R".to_string()],
+        );
+
+        let json = envelope.to_json_pretty().unwrap();
+        let restored = RdAstEnvelope::from_json(&json).unwrap();
+
+        assert_eq!(envelope, restored);
+    }
+
+    #[test]
+    fn test_envelope_json_is_camel_case() {
+        let envelope = RdAstEnvelope::new(
+            sample_document(),
+            Some("foo.Rd".to_string()),
+            vec!["R/foo.R".to_string()],
+        );
+
+        let json = envelope.to_json_pretty().unwrap();
+        assert!(json.contains("\"sourceFiles\""));
+        assert!(!json.contains("\"source_files\""));
+    }
+
+    #[test]
+    fn test_envelope_version_mismatch() {
+        let json = r#"{"version":99,"source":null,"sourceFiles":[],"document":{"sections":[]}}"#;
+        let err = RdAstEnvelope::from_json(json).unwrap_err();
+        assert!(matches!(
+            err,
+            AstIoError::VersionMismatch {
+                expected: AST_FORMAT_VERSION,
+                found: 99
+            }
+        ));
+    }
+}

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -37,6 +37,10 @@
 //! let qmd = convert_rd_content(r#"\name{foo}\title{Foo}\description{A function.}"#, &options).unwrap();
 //! ```
 //!
+//! [`convert_rd_document`] is the same pipeline for callers that already have
+//! a parsed [`RdDocument`] (e.g. from an [`RdAstEnvelope`]); it cannot fail
+//! with a parse error.
+//!
 //! ## Low-level: [`rd_to_mdast`] / [`rd_to_mdast_with_options`]
 //!
 //! For advanced use cases requiring direct access to the mdast intermediate representation.
@@ -58,6 +62,7 @@
 //! - `roxygen`: Enable source file extraction from roxygen2 comments
 //!   and roxygen2 markdown code block handling
 
+pub mod ast_io;
 pub mod convert;
 
 #[cfg(feature = "roxygen")]
@@ -67,6 +72,8 @@ use std::collections::HashMap;
 
 // Re-export rd-parser types
 pub use rd_parser::{RdDocument, RdNode, RdSection, SectionTag, parse};
+
+pub use ast_io::{AST_FORMAT_VERSION, AstIoError, RdAstEnvelope};
 
 // ============================================================================
 // Error types
@@ -489,6 +496,39 @@ pub fn convert_rd_content(
 ) -> Result<String, ConvertError> {
     let doc = parse(content).map_err(|e| ConvertError::Parse(e.to_string()))?;
 
+    #[cfg(feature = "roxygen")]
+    let source_files = rd_parser::parse_roxygen_comments(content).source_files;
+    #[cfg(not(feature = "roxygen"))]
+    let source_files = vec![];
+
+    Ok(convert_rd_document(&doc, source_files, options))
+}
+
+/// Convert an already-parsed Rd document to Quarto Markdown
+///
+/// This is the same conversion pipeline as [`convert_rd_content`], but takes
+/// an already-parsed [`RdDocument`] (e.g. deserialized from an
+/// [`RdAstEnvelope`]) instead of raw Rd content, so it cannot fail with a
+/// parse error.
+///
+/// `source_files` is the roxygen2-derived list of R source files (see
+/// `rd_parser::parse_roxygen_comments`), since that information is extracted
+/// from raw Rd text and is not part of the AST itself.
+///
+/// # Example
+///
+/// ```
+/// use rd2qmd_core::{convert_rd_document, parse, RdConvertOptions};
+///
+/// let doc = parse(r#"\name{foo}\title{Foo}\description{A function.}"#).unwrap();
+/// let qmd = convert_rd_document(&doc, vec![], &RdConvertOptions::default());
+/// assert!(qmd.contains("Foo"));
+/// ```
+pub fn convert_rd_document(
+    doc: &RdDocument,
+    source_files: Vec<String>,
+    options: &RdConvertOptions,
+) -> String {
     // Build converter options
     let converter_options = RdToMdastOptions {
         internal_link_url: options.links.internal_link_url.clone(),
@@ -505,7 +545,7 @@ pub fn convert_rd_content(
     };
 
     // Convert to mdast
-    let mdast = rd_to_mdast_with_options(&doc, &converter_options);
+    let mdast = rd_to_mdast_with_options(doc, &converter_options);
 
     // Extract title and name for frontmatter
     let title = doc
@@ -526,12 +566,7 @@ pub fn convert_rd_content(
     };
 
     // Extract metadata
-    #[cfg(feature = "roxygen")]
-    let source_files = rd_parser::parse_roxygen_comments(content).source_files;
-    #[cfg(not(feature = "roxygen"))]
-    let source_files = vec![];
-
-    let metadata = extract_rd_metadata(&doc, source_files);
+    let metadata = extract_rd_metadata(doc, source_files);
 
     // Build writer options
     let writer_options = WriterOptions {
@@ -548,7 +583,7 @@ pub fn convert_rd_content(
         quarto_code_blocks: options.code.quarto_code_blocks,
     };
 
-    Ok(mdast_to_qmd(&mdast, &writer_options))
+    mdast_to_qmd(&mdast, &writer_options)
 }
 
 #[cfg(test)]
@@ -1073,5 +1108,39 @@ for \eqn{x = 0, 1, 2, \ldots}{x = 0, 1, 2, ...}. The mean is
         let result = RdConverter::new(content).convert();
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_convert_rd_document_matches_convert_rd_content() {
+        let content = r#"\name{foo}
+\title{Foo Function}
+\description{Does foo. See \link{bar}.}
+"#;
+        let mut alias_map = HashMap::new();
+        alias_map.insert("bar".to_string(), "bar_file".to_string());
+
+        let options = RdConvertOptions {
+            frontmatter: FrontmatterOptions {
+                enabled: true,
+                pagetitle: true,
+            },
+            links: LinkOptions {
+                internal_link_url: Some("{file}.qmd".to_string()),
+                alias_map: Some(alias_map),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let from_content = convert_rd_content(content, &options).unwrap();
+
+        let doc = parse(content).unwrap();
+        #[cfg(feature = "roxygen")]
+        let source_files = rd_parser::parse_roxygen_comments(content).source_files;
+        #[cfg(not(feature = "roxygen"))]
+        let source_files = vec![];
+        let from_document = convert_rd_document(&doc, source_files, &options);
+
+        assert_eq!(from_content, from_document);
     }
 }

--- a/crates/rd2qmd-package/src/external_links.rs
+++ b/crates/rd2qmd-package/src/external_links.rs
@@ -282,15 +282,15 @@ impl PackageUrlResolver {
 
 /// Collect all external package references from an RdPackage
 ///
-/// Scans all Rd files for `\link[pkg]{topic}` patterns and returns
-/// the set of unique external package names.
+/// Scans all documentation files for `\link[pkg]{topic}` patterns and
+/// returns the set of unique external package names. Respects the
+/// package's [`InputFormat`](crate::InputFormat): `.Rd` files are parsed,
+/// AST JSON envelopes are decoded directly.
 pub fn collect_external_packages(package: &RdPackage) -> HashSet<String> {
     let mut packages = HashSet::new();
 
     for file in &package.files {
-        if let Ok(content) = fs::read_to_string(file)
-            && let Ok(doc) = rd2qmd_core::parse(&content)
-        {
+        if let Ok((doc, _)) = crate::load_document(file, package.format) {
             for section in &doc.sections {
                 collect_packages_from_nodes(&section.content, &mut packages);
             }
@@ -464,6 +464,41 @@ Also \link[base]{paste} and \link{local_func}.
         assert!(external.contains("base"));
         // local_func should not be included (no package specified)
         assert!(!external.contains("local_func"));
+    }
+
+    #[test]
+    fn test_collect_external_packages_ast_json() {
+        let dir = tempdir().unwrap();
+        let man_dir = dir.path().join("man");
+        fs::create_dir_all(&man_dir).unwrap();
+
+        let rd_content = r#"\name{test}
+\alias{test}
+\title{Test}
+\description{
+See \link[dplyr]{mutate} and \link[base]{paste}.
+}
+"#;
+        fs::write(man_dir.join("test.Rd"), rd_content).unwrap();
+
+        let json_dir = dir.path().join("json");
+        crate::export_package_ast(&man_dir, false, &json_dir, Some(1)).unwrap();
+
+        let package =
+            RdPackage::from_directory_with_format(&json_dir, false, crate::InputFormat::AstJson)
+                .unwrap();
+        let external = collect_external_packages(&package);
+
+        assert!(
+            external.contains("dplyr"),
+            "Expected 'dplyr' in {:?}",
+            external
+        );
+        assert!(
+            external.contains("base"),
+            "Expected 'base' in {:?}",
+            external
+        );
     }
 
     #[test]

--- a/crates/rd2qmd-package/src/lib.rs
+++ b/crates/rd2qmd-package/src/lib.rs
@@ -34,9 +34,9 @@ pub enum FallbackReason {
 
 use rayon::prelude::*;
 use rd2qmd_core::{
-    ArgumentsFormat, Frontmatter, RdMetadata, RdToMdastOptions, SectionTag, WriterOptions,
-    extract_rd_metadata, extract_text, mdast_to_qmd, parse, parse_roxygen_comments,
-    rd_to_mdast_with_options,
+    ArgumentsFormat, Frontmatter, RdAstEnvelope, RdDocument, RdMetadata, RdToMdastOptions,
+    SectionTag, WriterOptions, extract_rd_metadata, extract_text, mdast_to_qmd, parse,
+    parse_roxygen_comments, rd_to_mdast_with_options,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -71,6 +71,16 @@ enum ConvertError {
     Failed(String),
 }
 
+/// Input format for a package's documentation files
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum InputFormat {
+    /// Parse `.Rd` files (default)
+    #[default]
+    Rd,
+    /// Decode pre-parsed AST JSON envelopes (`.json` files, see [`RdAstEnvelope`])
+    AstJson,
+}
+
 /// Information about an R package's documentation
 #[derive(Debug, Clone)]
 pub struct RdPackage {
@@ -80,6 +90,8 @@ pub struct RdPackage {
     files: Vec<PathBuf>,
     /// Alias index: maps alias names to Rd file basenames (without extension)
     alias_index: HashMap<String, String>,
+    /// Format of the files in this package
+    format: InputFormat,
 }
 
 impl RdPackage {
@@ -88,17 +100,31 @@ impl RdPackage {
     /// This scans the directory for .Rd files and builds an alias index
     /// by parsing each file and extracting \alias{} tags.
     pub fn from_directory(path: &Path, recursive: bool) -> Result<Self> {
+        Self::from_directory_with_format(path, recursive, InputFormat::Rd)
+    }
+
+    /// Load a package from a directory containing Rd files or AST JSON files
+    ///
+    /// With [`InputFormat::AstJson`], the directory is scanned for `.json`
+    /// files instead of `.Rd`/`.rd` files, and each file is decoded as an
+    /// [`RdAstEnvelope`] instead of being parsed as Rd.
+    pub fn from_directory_with_format(
+        path: &Path,
+        recursive: bool,
+        format: InputFormat,
+    ) -> Result<Self> {
         if !path.is_dir() {
             return Err(PackageError::DirectoryNotFound(path.to_path_buf()));
         }
 
-        let files = collect_rd_files(path, recursive)?;
-        let alias_index = build_alias_index(&files)?;
+        let files = collect_files(path, recursive, format)?;
+        let alias_index = build_alias_index(&files, format)?;
 
         Ok(Self {
             root: path.to_path_buf(),
             files,
             alias_index,
+            format,
         })
     }
 
@@ -281,7 +307,7 @@ pub fn generate_topic_index(
     let mut topics = Vec::new();
 
     for file in &package.files {
-        match extract_topic_info(file, &options.output_extension) {
+        match extract_topic_info(file, &options.output_extension, package.format) {
             Ok(info) => {
                 // Skip internal topics unless include_internal is set
                 if !options.include_internal
@@ -309,16 +335,12 @@ pub fn generate_topic_index(
 }
 
 /// Extract topic information from a single Rd file
-fn extract_topic_info(file: &Path, output_extension: &str) -> Result<TopicInfo> {
-    let content = fs::read_to_string(file)?;
-
-    // Extract roxygen2 metadata (source files) from header comments
-    let roxygen = parse_roxygen_comments(&content);
-
-    let doc = parse(&content).map_err(|e| PackageError::Parse {
-        file: file.to_path_buf(),
-        message: e.to_string(),
-    })?;
+fn extract_topic_info(
+    file: &Path,
+    output_extension: &str,
+    format: InputFormat,
+) -> Result<TopicInfo> {
+    let (doc, source_files) = load_document(file, format)?;
 
     // Extract name
     let name = doc
@@ -333,7 +355,7 @@ fn extract_topic_info(file: &Path, output_extension: &str) -> Result<TopicInfo> 
         .unwrap_or_default();
 
     // Extract metadata using shared function
-    let metadata = extract_rd_metadata(&doc, roxygen.source_files);
+    let metadata = extract_rd_metadata(&doc, source_files);
 
     // Determine output filename
     let basename = file.file_stem().and_then(|s| s.to_str()).unwrap_or("");
@@ -412,6 +434,108 @@ pub fn convert_package(
     })
 }
 
+/// Export all Rd files in a directory as AST JSON envelopes
+///
+/// Each `.Rd` file is parsed, its roxygen2-derived `source_files` are
+/// extracted, and the result is wrapped in an [`RdAstEnvelope`] and written
+/// as a `<stem>.json` file, mirroring the input file's relative path under
+/// `output_dir`.
+///
+/// Unlike [`convert_package`], this does not build an alias index (link
+/// resolution happens later, at conversion time) and applies no
+/// `\keyword{internal}` filtering: every file is exported, since filtering
+/// is the responsibility of the final conversion stage.
+pub fn export_package_ast(
+    input_dir: &Path,
+    recursive: bool,
+    output_dir: &Path,
+    jobs: Option<usize>,
+) -> Result<ConvertResult> {
+    if !input_dir.is_dir() {
+        return Err(PackageError::DirectoryNotFound(input_dir.to_path_buf()));
+    }
+
+    // Configure thread pool if specified
+    if let Some(n) = jobs {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global()
+            .ok();
+    }
+
+    let files = collect_files(input_dir, recursive, InputFormat::Rd)?;
+
+    // Create output directory if needed
+    fs::create_dir_all(output_dir)?;
+
+    // Export files in parallel
+    let results: Vec<_> = files
+        .par_iter()
+        .map(|file| export_single_file(file, input_dir, output_dir))
+        .collect();
+
+    // Collect results
+    let mut success_count = 0;
+    let mut failed_files = Vec::new();
+    let mut output_files = Vec::new();
+
+    for result in results {
+        match result {
+            Ok(output_path) => {
+                success_count += 1;
+                output_files.push(output_path);
+            }
+            Err((input_path, message)) => {
+                failed_files.push((input_path, message));
+            }
+        }
+    }
+
+    Ok(ConvertResult {
+        success_count,
+        failed_files,
+        output_files,
+        skipped_internal: Vec::new(),
+    })
+}
+
+/// Parse a single Rd file and write it as an AST JSON envelope
+fn export_single_file(
+    input: &Path,
+    root: &Path,
+    output_dir: &Path,
+) -> std::result::Result<PathBuf, (PathBuf, String)> {
+    let export = || -> std::result::Result<PathBuf, String> {
+        let content = fs::read_to_string(input).map_err(|e| e.to_string())?;
+
+        let roxygen = parse_roxygen_comments(&content);
+        let doc = parse(&content).map_err(|e| format!("Parse error: {}", e))?;
+
+        let source = input
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string());
+        let envelope = RdAstEnvelope::new(doc, source, roxygen.source_files);
+        let json = envelope.to_json_pretty().map_err(|e| e.to_string())?;
+
+        // Determine output path
+        let relative = input.strip_prefix(root).unwrap_or(input);
+        let output_path = output_dir.join(relative).with_extension("json");
+
+        // Create parent directory if needed
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+
+        // Write output
+        fs::write(&output_path, json).map_err(|e| e.to_string())?;
+
+        Ok(output_path)
+    };
+
+    export().map_err(|message| (input.to_path_buf(), message))
+}
+
 /// Check if a document has \keyword{internal}
 fn has_keyword_internal(doc: &rd2qmd_core::RdDocument) -> bool {
     doc.get_sections(&SectionTag::Keyword)
@@ -426,12 +550,9 @@ fn convert_single_file(
     options: &PackageConvertOptions,
 ) -> ConvertOutcome {
     let convert = || -> std::result::Result<PathBuf, ConvertError> {
-        // Read input file
-        let content = fs::read_to_string(input).map_err(|e| ConvertError::Failed(e.to_string()))?;
-
-        // Parse Rd
-        let doc =
-            parse(&content).map_err(|e| ConvertError::Failed(format!("Parse error: {}", e)))?;
+        // Read and parse the input file (Rd or AST JSON, depending on package.format)
+        let (doc, source_files) = load_document(input, package.format)
+            .map_err(|e| ConvertError::Failed(e.to_string()))?;
 
         // Check for \keyword{internal} - skip unless include_internal is set
         if !options.include_internal && has_keyword_internal(&doc) {
@@ -480,8 +601,7 @@ fn convert_single_file(
         };
 
         // Extract Rd metadata, including source files from roxygen2 comments
-        let roxygen = parse_roxygen_comments(&content);
-        let metadata = extract_rd_metadata(&doc, roxygen.source_files);
+        let metadata = extract_rd_metadata(&doc, source_files);
 
         // Build writer options
         let writer_options = WriterOptions {
@@ -526,8 +646,11 @@ fn convert_single_file(
     }
 }
 
-/// Collect all .Rd files in a directory
-fn collect_rd_files(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>> {
+/// Collect all documentation files in a directory
+///
+/// Scans for `.Rd`/`.rd` files with [`InputFormat::Rd`], or `.json` files
+/// with [`InputFormat::AstJson`].
+fn collect_files(dir: &Path, recursive: bool, format: InputFormat) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
 
     for entry in fs::read_dir(dir)? {
@@ -535,23 +658,58 @@ fn collect_rd_files(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>> {
         let path = entry.path();
 
         if path.is_file() {
-            if let Some(ext) = path.extension()
-                && ext.eq_ignore_ascii_case("rd")
-            {
+            let matches = match format {
+                InputFormat::Rd => path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("rd")),
+                InputFormat::AstJson => path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("json")),
+            };
+            if matches {
                 files.push(path);
             }
         } else if path.is_dir() && recursive {
-            files.extend(collect_rd_files(&path, recursive)?);
+            files.extend(collect_files(&path, recursive, format)?);
         }
     }
 
     Ok(files)
 }
 
-/// Build an alias index from a list of Rd files
+/// Read and parse a single documentation file, returning its AST and the
+/// roxygen2-derived list of R source files
 ///
-/// Returns a HashMap mapping alias names to Rd file basenames (without extension)
-fn build_alias_index(files: &[PathBuf]) -> Result<HashMap<String, String>> {
+/// With [`InputFormat::Rd`], the file is read as Rd source and parsed; the
+/// source files are extracted from roxygen2 header comments. With
+/// [`InputFormat::AstJson`], the file is decoded as an [`RdAstEnvelope`]
+/// instead, and its `source_files` field is used directly.
+fn load_document(path: &Path, format: InputFormat) -> Result<(RdDocument, Vec<String>)> {
+    let content = fs::read_to_string(path)?;
+
+    match format {
+        InputFormat::Rd => {
+            let roxygen = parse_roxygen_comments(&content);
+            let doc = parse(&content).map_err(|e| PackageError::Parse {
+                file: path.to_path_buf(),
+                message: e.to_string(),
+            })?;
+            Ok((doc, roxygen.source_files))
+        }
+        InputFormat::AstJson => {
+            let envelope = RdAstEnvelope::from_json(&content).map_err(|e| PackageError::Parse {
+                file: path.to_path_buf(),
+                message: e.to_string(),
+            })?;
+            Ok((envelope.document, envelope.source_files))
+        }
+    }
+}
+
+/// Build an alias index from a list of documentation files
+///
+/// Returns a HashMap mapping alias names to file basenames (without extension)
+fn build_alias_index(files: &[PathBuf], format: InputFormat) -> Result<HashMap<String, String>> {
     let mut index = HashMap::new();
 
     for file in files {
@@ -561,12 +719,7 @@ fn build_alias_index(files: &[PathBuf]) -> Result<HashMap<String, String>> {
             .unwrap_or("")
             .to_string();
 
-        // Parse the file to extract aliases
-        let content = fs::read_to_string(file)?;
-        let doc = parse(&content).map_err(|e| PackageError::Parse {
-            file: file.clone(),
-            message: e.to_string(),
-        })?;
+        let (doc, _source_files) = load_document(file, format)?;
 
         // Extract all \alias{} sections
         let alias_sections = doc.get_sections(&SectionTag::Alias);
@@ -783,7 +936,7 @@ mod tests {
         fs::write(&rd_path, rd_content).unwrap();
 
         let files = vec![rd_path];
-        let index = build_alias_index(&files).unwrap();
+        let index = build_alias_index(&files, InputFormat::Rd).unwrap();
 
         assert_eq!(index.get("my_func"), Some(&"my_func".to_string()));
         assert_eq!(index.get("my_func_alias"), Some(&"my_func".to_string()));
@@ -1727,5 +1880,147 @@ x <- 1
         let names: Vec<_> = index.topics.iter().map(|t| t.name.as_str()).collect();
         assert!(names.contains(&"public_func"));
         assert!(names.contains(&"internal_func"));
+    }
+
+    // ========================================================================
+    // AST JSON export/import tests
+    // ========================================================================
+
+    #[test]
+    fn test_export_package_ast() {
+        let dir = tempdir().unwrap();
+        let out_dir = tempdir().unwrap();
+
+        let rd_roxygen = r#"% Generated by roxygen2: do not edit by hand
+% Please edit documentation in R/coord-map.R
+\name{coord_map}
+\alias{coord_map}
+\title{Map projections}
+\description{Projects coordinates onto a map.}
+"#;
+        fs::write(dir.path().join("coord_map.Rd"), rd_roxygen).unwrap();
+
+        let result = export_package_ast(dir.path(), false, out_dir.path(), Some(1)).unwrap();
+
+        assert_eq!(result.success_count, 1);
+        assert!(result.failed_files.is_empty());
+        assert!(result.skipped_internal.is_empty());
+
+        let json_path = out_dir.path().join("coord_map.json");
+        assert!(json_path.exists());
+
+        let content = fs::read_to_string(&json_path).unwrap();
+        let envelope = RdAstEnvelope::from_json(&content).unwrap();
+        assert_eq!(envelope.source, Some("coord_map.Rd".to_string()));
+        assert_eq!(envelope.source_files, vec!["R/coord-map.R".to_string()]);
+    }
+
+    #[test]
+    fn test_export_package_ast_exports_internal_topics_too() {
+        let dir = tempdir().unwrap();
+        let out_dir = tempdir().unwrap();
+
+        let rd_internal = r#"\name{internal_func}
+\alias{internal_func}
+\title{Internal Function}
+\keyword{internal}
+\description{An internal function.}
+"#;
+        fs::write(dir.path().join("internal_func.Rd"), rd_internal).unwrap();
+
+        let result = export_package_ast(dir.path(), false, out_dir.path(), Some(1)).unwrap();
+
+        assert_eq!(result.success_count, 1);
+        assert!(out_dir.path().join("internal_func.json").exists());
+    }
+
+    #[test]
+    fn test_package_from_directory_with_ast_json_format() {
+        let dir = tempdir().unwrap();
+        let json_dir = tempdir().unwrap();
+        let out_dir = tempdir().unwrap();
+
+        let rd_main = r#"\name{main_func}
+\alias{main_func}
+\title{Main Function}
+\description{See \link{helper_func} for details.}
+"#;
+        let rd_helper = r#"\name{helper_func}
+\alias{helper_func}
+\title{Helper Function}
+\description{A helper function.}
+"#;
+        fs::write(dir.path().join("main_func.Rd"), rd_main).unwrap();
+        fs::write(dir.path().join("helper_func.Rd"), rd_helper).unwrap();
+
+        export_package_ast(dir.path(), false, json_dir.path(), Some(1)).unwrap();
+
+        let package =
+            RdPackage::from_directory_with_format(json_dir.path(), false, InputFormat::AstJson)
+                .unwrap();
+        assert_eq!(package.files.len(), 2);
+        assert_eq!(package.resolve_alias("main_func"), Some("main_func"));
+        assert_eq!(package.resolve_alias("helper_func"), Some("helper_func"));
+
+        let options = PackageConvertOptions {
+            output_dir: out_dir.path().to_path_buf(),
+            frontmatter: false,
+            pagetitle: false,
+            parallel_jobs: Some(1),
+            ..Default::default()
+        };
+        let result = PackageConverter::new(&package, options).convert().unwrap();
+        assert_eq!(result.conversion.success_count, 2);
+
+        let main_content = fs::read_to_string(out_dir.path().join("main_func.qmd")).unwrap();
+        assert!(main_content.contains("[`helper_func`](helper_func.qmd)"));
+    }
+
+    #[test]
+    fn test_topic_index_from_ast_json_format() {
+        let dir = tempdir().unwrap();
+        let json_dir = tempdir().unwrap();
+
+        let rd_roxygen = r#"% Generated by roxygen2: do not edit by hand
+% Please edit documentation in R/coord-map.R
+\name{coord_map}
+\alias{coord_map}
+\title{Map projections}
+\description{Projects coordinates onto a map.}
+"#;
+        fs::write(dir.path().join("coord_map.Rd"), rd_roxygen).unwrap();
+
+        export_package_ast(dir.path(), false, json_dir.path(), Some(1)).unwrap();
+
+        let package =
+            RdPackage::from_directory_with_format(json_dir.path(), false, InputFormat::AstJson)
+                .unwrap();
+        let options = TopicIndexOptions {
+            output_extension: "qmd".to_string(),
+            include_internal: false,
+        };
+        let index = generate_topic_index(&package, &options).unwrap();
+
+        assert_eq!(index.topics.len(), 1);
+        assert_eq!(index.topics[0].name, "coord_map");
+        assert_eq!(
+            index.topics[0].metadata.source_files,
+            vec!["R/coord-map.R".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_ast_json_version_mismatch_reported_as_parse_error() {
+        let json_dir = tempdir().unwrap();
+        fs::write(
+            json_dir.path().join("broken.json"),
+            r#"{"version":99,"source":null,"sourceFiles":[],"document":{"sections":[]}}"#,
+        )
+        .unwrap();
+
+        let result =
+            RdPackage::from_directory_with_format(json_dir.path(), false, InputFormat::AstJson);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("broken.json"));
     }
 }


### PR DESCRIPTION
## Summary

Adds a two-stage pipeline capability: Rd → AST JSON → (rewrite with any external tooling) → qmd/md.

- New `parse` subcommand: parses Rd files (single file or directory) into a versioned JSON envelope (`{"version": 1, "source": ..., "sourceFiles": ..., "document": ...}`) instead of converting directly. Takes only input / `-o` / `-r` / `-j` (plus global `-v`/`-q`); no conversion options, does not read `_rd2qmd.toml`, no internal-topic filtering.
- New `--input-format <rd|ast>` on `convert` and `index` to consume AST JSON; a `.json` input is auto-detected in single-file mode. All directory-mode features (alias/internal-link resolution, `--topic-index`, external link resolution) work identically with AST input.
- The AST is output-format-independent (links keep raw Rd semantics; URL resolution happens at conversion time), so one `parse` run can feed both qmd and md outputs.

Motivating recipe (rewriting usage sections with external tooling):

```sh
rd2qmd parse man/ -o tmp_ast/
# rewrite text nodes inside tmp_ast/*.json with any tool/language you like
rd2qmd convert tmp_ast/ --input-format ast -o docs/man/ --topic-index index.json
```

## Implementation

- `rd2qmd-core`: new `ast_io` module (`RdAstEnvelope`, `AST_FORMAT_VERSION = 1`, dedicated version-mismatch error) and a `convert_rd_document()` entry point for already-parsed documents; `convert_rd_content()` now delegates to it (single conversion code path).
- `rd2qmd-package`: `InputFormat` enum, `from_directory_with_format()`, a unified `load_document()` helper shared by alias-index building / conversion / topic-info extraction / external-link collection, and `export_package_ast()` (parallel per-file envelope export).
- CLI: `parse` subcommand wiring and `--input-format` plumbing; `_rd2qmd.toml` schema intentionally unchanged (pipeline flags are not project config).

## Test plan

- Integration tests: parse→convert round-trip is byte-identical to direct conversion (single file and directory), `sourceFiles` frontmatter survives the round trip, version-mismatch envelopes fail with a clear error, and a parse → edit JSON → convert pipeline test mirroring the recipe above.
- Unit tests for envelope round-trip, camelCase field names, and version mismatch (including values beyond `u32::MAX`).
- `cargo test --all-targets --all-features --workspace`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, and `cargo fmt --all --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)