### PR TITLE
chore: prepare release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-05
+
 ### Added
 
-- Add a `parse` subcommand that parses Rd files (single file or directory) to AST JSON instead of converting them directly, so external tooling can inspect or rewrite the parsed document before running `convert`. The output is a versioned envelope (`{"version": 1, "source": ..., "sourceFiles": ..., "document": ...}`) around an output-format-independent AST — links keep their raw Rd semantics, with URL resolution and `.qmd`/`.md` extensions applied only at conversion time.
-- Add `--input-format <rd|ast>` to `convert` and `index` to read AST JSON produced by `parse` instead of `.Rd` files (a `.json` input is auto-detected in single-file mode without the flag). Directory-mode features such as alias/internal-link resolution work identically with AST input.
-- Add `--prefer-ascii-math` option (config: `output.prefer_ascii_math`) to prefer the plain-text representation of `\eqn{latex}{ascii}` / `\deqn{latex}{ascii}` equations over LaTeX math, for renderers without math support such as terminal pagers. `\eqn` is output as inline code and `\deqn` as a plain code block.
+- Add a `parse` subcommand that parses Rd files (single file or directory) to AST JSON instead of converting them directly, so external tooling can inspect or rewrite the parsed document before running `convert`. The output is a versioned envelope (`{"version": 1, "source": ..., "sourceFiles": ..., "document": ...}`) around an output-format-independent AST — links keep their raw Rd semantics, with URL resolution and `.qmd`/`.md` extensions applied only at conversion time. (#43)
+- Add `--input-format <rd|ast>` to `convert` and `index` to read AST JSON produced by `parse` instead of `.Rd` files (a `.json` input is auto-detected in single-file mode without the flag). Directory-mode features such as alias/internal-link resolution work identically with AST input. (#43)
+- Add `--prefer-ascii-math` option (config: `output.prefer_ascii_math`) to prefer the plain-text representation of `\eqn{latex}{ascii}` / `\deqn{latex}{ascii}` equations over LaTeX math, for renderers without math support such as terminal pagers. `\eqn` is output as inline code and `\deqn` as a plain code block. (#39)
 
 ### Changed
 
@@ -21,11 +23,15 @@
 
   Qualified links resolve through `package_urls`, then `--external-link-url` (default: `https://rdrr.io/pkg/{package}/man/{topic}.html`, now applied even when external link resolution is disabled), then inline code. Unqualified links resolve through the alias index rendered with `internal_link_url`, then `--unqualified-link-url` (default: `https://rdrr.io/r/base/{topic}.html`), then inline code. Both fallbacks can be disabled with `--no-external-link-url` / `--no-unqualified-link-url`.
 
-  External link resolution no longer synthesizes fallback URLs itself; packages it cannot resolve now fall back to `--external-link-url`. Manually specified `links.package_urls` entries take precedence over automatically resolved ones.
+  External link resolution no longer synthesizes fallback URLs itself; packages it cannot resolve now fall back to `--external-link-url`. Manually specified `links.package_urls` entries take precedence over automatically resolved ones. (#37)
 
-- Links whose text equals their URL (e.g. from `\url{}`) are now written as CommonMark autolinks (`<https://example.com>` instead of `[https://example.com](https://example.com)`), so renderers that display link URLs alongside the text no longer show the URL twice.
+- Links whose text equals their URL (e.g. from `\url{}`) are now written as CommonMark autolinks (`<https://example.com>` instead of `[https://example.com](https://example.com)`), so renderers that display link URLs alongside the text no longer show the URL twice. (#38)
 
-- **Breaking:** Conversion is now a `convert` subcommand instead of the top-level command, e.g. `rd2qmd man/ -o docs/` becomes `rd2qmd convert man/ -o docs/`. Running `rd2qmd` with no arguments now shows the help text instead of erroring. `-v`/`--verbose` and `-q`/`--quiet` are now global flags accepted by every subcommand (e.g. `rd2qmd index -v`).
+- **Breaking:** Conversion is now a `convert` subcommand instead of the top-level command, e.g. `rd2qmd man/ -o docs/` becomes `rd2qmd convert man/ -o docs/`. Running `rd2qmd` with no arguments now shows the help text instead of erroring. `-v`/`--verbose` and `-q`/`--quiet` are now global flags accepted by every subcommand (e.g. `rd2qmd index -v`). (#42)
+
+### Fixed
+
+- Preserve whitespace following `\eqn` and `\deqn` macros when their optional second argument is absent. (#40)
 
 ## [0.3.0] - 2026-07-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "rd-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "serde",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "rd-parser",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "serde",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-package"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "r-description",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/rd2qmd-cli"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -43,10 +43,10 @@ url = "2"
 insta = { version = "1", features = ["yaml"] }
 
 # Internal crates
-rd2qmd-mdast = { version = "0.3.0", path = "crates/rd2qmd-mdast" }
-rd-parser = { version = "0.3.0", path = "crates/rd-parser" }
-rd2qmd-core = { version = "0.3.0", path = "crates/rd2qmd-core" }
-rd2qmd-package = { version = "0.3.0", path = "crates/rd2qmd-package" }
+rd2qmd-mdast = { version = "0.4.0", path = "crates/rd2qmd-mdast" }
+rd-parser = { version = "0.4.0", path = "crates/rd-parser" }
+rd2qmd-core = { version = "0.4.0", path = "crates/rd2qmd-core" }
+rd2qmd-package = { version = "0.4.0", path = "crates/rd2qmd-package" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.3.0 to 0.4.0
- Finalize CHANGELOG `[Unreleased]` section as `[0.4.0] - 2026-07-05`
- Update workspace package versions in `Cargo.lock`

## Changelog

See the finalized `[0.4.0]` section in `CHANGELOG.md`.