### PR TITLE
fix: collapse excessive prose spaces at Rd AST boundaries

### DIFF
--- a/crates/rd2qmd-cli/tests/fixtures/issue_54.Rd
+++ b/crates/rd2qmd-cli/tests/fixtures/issue_54.Rd
@@ -1,0 +1,6 @@
+\name{issue-54}
+\title{Adjacent prose text nodes}
+\description{
+First sentence ends here
+ Second sentence starts with a space.
+}

--- a/crates/rd2qmd-cli/tests/fixtures/issue_54.Rd
+++ b/crates/rd2qmd-cli/tests/fixtures/issue_54.Rd
@@ -3,4 +3,5 @@
 \description{
 First sentence ends here
  Second sentence starts with a space.
+    Third sentence starts with four spaces.
 }

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -179,6 +179,15 @@ fn test_formatting() {
     insta::assert_snapshot!("formatting_qmd", output);
 }
 
+/// A prose line wrap can produce adjacent `rd_ast::Text` nodes with
+/// whitespace on both sides of the node boundary. The core converter must
+/// collapse that boundary to one prose space after the real parser path.
+#[test]
+fn test_issue_54_adjacent_prose_text_nodes() {
+    let output = convert_fixture("issue_54", &["--no-frontmatter"]);
+    insta::assert_snapshot!("issue_54_qmd", output);
+}
+
 #[test]
 fn test_example_control() {
     let output = convert_fixture("example_control", &[]);

--- a/crates/rd2qmd-cli/tests/snapshots/integration__directory_files.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__directory_files.snap
@@ -7,6 +7,7 @@ expression: files
 - example_control.qmd
 - examplesif.qmd
 - formatting.qmd
+- issue_54.qmd
 - methods.qmd
 - roxygen_code_blocks.qmd
 - simple.qmd

--- a/crates/rd2qmd-cli/tests/snapshots/integration__issue_54_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__issue_54_qmd.snap
@@ -6,4 +6,4 @@ expression: output
 
 ## Description
 
-First sentence ends here Second sentence starts with a space.
+First sentence ends here Second sentence starts with a space. Third sentence starts with four spaces.

--- a/crates/rd2qmd-cli/tests/snapshots/integration__issue_54_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__issue_54_qmd.snap
@@ -1,0 +1,9 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+# Adjacent prose text nodes
+
+## Description
+
+First sentence ends here Second sentence starts with a space.

--- a/crates/rd2qmd-core/src/convert_ast/assembly.rs
+++ b/crates/rd2qmd-core/src/convert_ast/assembly.rs
@@ -218,6 +218,25 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_adjacent_prose_text_nodes_to_one_boundary_space() {
+        let document = RdDocument::new(vec![RdNode::tagged(
+            RdTag::Description,
+            None,
+            vec![
+                RdNode::Text("The first text node ends with a space. ".to_owned()),
+                RdNode::Text(" The second text node starts with a space.".to_owned()),
+            ],
+        )]);
+
+        let markdown = render_new(&document, &RdToMdastOptions::default());
+
+        assert_eq!(
+            markdown,
+            "## Description\n\nThe first text node ends with a space. The second text node starts with a space.\n"
+        );
+    }
+
+    #[test]
     fn title_heading_respects_include_title_heading() {
         let document = RdDocument::new(vec![
             section(RdTag::Name, "topic"),

--- a/crates/rd2qmd-core/src/convert_ast/traversal.rs
+++ b/crates/rd2qmd-core/src/convert_ast/traversal.rs
@@ -36,7 +36,7 @@ pub(crate) fn scan_block_content(nodes: &[rd_ast::RdNode]) -> Vec<BlockContentIt
 #[derive(Default)]
 struct ScanState<'a> {
     current: Vec<ParagraphItem<'a>>,
-    pending_whitespace: Vec<&'a str>,
+    pending_whitespace: bool,
     pending_newlines: usize,
     has_visible: bool,
 }
@@ -89,10 +89,10 @@ fn scan<'a>(
     }
 }
 
-fn append_whitespace<'a>(whitespace: &'a str, state: &mut ScanState<'a>) {
+fn append_whitespace(whitespace: &str, state: &mut ScanState<'_>) {
     if !whitespace.is_empty() {
         state.pending_newlines += whitespace.matches('\n').count();
-        state.pending_whitespace.push(whitespace);
+        state.pending_whitespace = true;
     }
 }
 
@@ -104,14 +104,17 @@ fn append_visible<'a>(
     if state.has_visible {
         if state.pending_newlines >= 2 {
             flush(state, items);
-        } else {
-            state
-                .current
-                .extend(state.pending_whitespace.drain(..).map(ParagraphItem::Text));
-            state.pending_newlines = 0;
+        } else if state.pending_whitespace {
+            // Text nodes can be split at markup boundaries while retaining
+            // whitespace on both sides of the boundary. Keep one logical
+            // prose separator instead of emitting one item for each source
+            // fragment (which would be normalized independently later).
+            state.current.push(ParagraphItem::Text(" "));
         }
+        state.pending_whitespace = false;
+        state.pending_newlines = 0;
     } else {
-        state.pending_whitespace.clear();
+        state.pending_whitespace = false;
         state.pending_newlines = 0;
     }
     state.current.push(item);
@@ -119,7 +122,7 @@ fn append_visible<'a>(
 }
 
 fn flush<'a>(state: &mut ScanState<'a>, items: &mut Vec<BlockContentItem<'a>>) {
-    state.pending_whitespace.clear();
+    state.pending_whitespace = false;
     state.pending_newlines = 0;
     if state.has_visible {
         items.push(BlockContentItem::Paragraph(std::mem::take(


### PR DESCRIPTION
Fixes #54.

## Summary

- Collapse duplicate whitespace at boundaries between adjacent ordinary prose Rd AST text nodes.
- Preserve paragraph breaks and keep code, backslash-cr, and preformatted contexts out of this normalization path.
- Add a core regression test plus a parser-to-CLI fixture and snapshot test.

## Root cause

The rd_ast migration in #50 introduced scan_block_content, which retained whitespace fragments and normalized each paragraph text fragment independently. Adjacent text nodes with boundary whitespace therefore emitted duplicate spaces. The parser and AST correctly retain Rd source whitespace, so the fix is scoped to rd2qmd-core paragraph assembly.

## Validation

- cargo test --all-targets --all-features --workspace
- cargo fmt --all -- --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- git diff --check

All checks pass.
