### PR TITLE
chore: prepare release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@
 
 ### Fixed
 
-- Collapse excessive prose spaces introduced at Rd AST node boundaries, so adjacent inline content no longer produces doubled-up whitespace in generated output. (#55)
-- Ignore RDS `USERMACRO` definition metadata when converting inline nodes, preventing duplicated macro metadata in generated help output. (#52)
 - Complete uniform suppression of the duplicate Rd title heading when YAML frontmatter is enabled across all output formats. (#49)
 - Preserve special-character macros, encoded text, and link/S4-class/DOI display text when extracting frontmatter metadata. (#49)
 - Enable a TLS backend for `reqwest` so external link resolution can actually fetch HTTPS `pkgdown.yml` sites instead of silently failing. (#49)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [0.5.0-beta.1] - 2026-07-24
+## [0.5.0] - 2026-07-26
 
 ### Changed
 
@@ -10,7 +10,7 @@
   - `rd2qmd-core`'s public API now operates directly on `rd_ast::RdDocument` (`convert_rd_document`, `rd_to_mdast`); the previous `RdConverter`/`convert_rd_content` API and all `rd_parser` re-exports are removed.
   - Bump the AST JSON envelope format version from 1 to 2 to match the new document shape.
   - Remove the `lifecycle` and `roxygen` Cargo library feature flags; roxygen2 fenced-code-block detection is now always enabled.
-- Update the `rd-ast` and `rd-source` dependencies to `0.1.0-rc.1`.
+- Update the `rd-ast` and `rd-source` dependencies to `0.1.0`.
 - Recoverable parser diagnostics are now surfaced end-to-end through the CLI, package converter, and topic index instead of being silently dropped. (#50)
 
 ### Added
@@ -19,6 +19,7 @@
 
 ### Fixed
 
+- Collapse excessive prose spaces introduced at Rd AST node boundaries, so adjacent inline content no longer produces doubled-up whitespace in generated output. (#55)
 - Ignore RDS `USERMACRO` definition metadata when converting inline nodes, preventing duplicated macro metadata in generated help output. (#52)
 - Complete uniform suppression of the duplicate Rd title heading when YAML frontmatter is enabled across all output formats. (#49)
 - Preserve special-character macros, encoded text, and link/S4-class/DOI display text when extracting frontmatter metadata. (#49)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,25 +1165,25 @@ dependencies = [
 
 [[package]]
 name = "rd-ast"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a90f843c732928497c9633c0e53836d09dc5b184226fa52ca023f79b9028dd"
+checksum = "0cd34b9f48d1d7e4b54fcb38e191460edaac7bcef76685235394649868e7c728"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rd-source"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f11c13c76965e24666211487409ee08ef55638cf713894a4f5063208847370"
+checksum = "498b9c8e7c53b728a85178ca0dcf37c432c108f104bf236d743cd0a33be3a85f"
 dependencies = [
  "rd-ast",
 ]
 
 [[package]]
 name = "rd2qmd"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "insta",
  "rd-ast",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "insta",
  "serde",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-package"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "r-description",
  "rayon",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-source"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "rd-ast",
  "rd-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/rd2qmd-cli"]
 
 [workspace.package]
-version = "0.5.0-beta.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -40,17 +40,17 @@ reqwest = { version = "0.13", features = ["blocking", "rustls"], default-feature
 url = "2"
 
 # R documentation AST and source parser
-rd-ast = { version = "=0.1.0-rc.1", features = ["serde"] }
-rd-source = "=0.1.0-rc.1"
+rd-ast = { version = "0.1.0", features = ["serde"] }
+rd-source = "0.1.0"
 
 # Testing
 insta = { version = "1", features = ["yaml"] }
 
 # Internal crates
-rd2qmd-mdast = { version = "0.5.0-beta.1", path = "crates/rd2qmd-mdast" }
-rd2qmd-core = { version = "0.5.0-beta.1", path = "crates/rd2qmd-core" }
-rd2qmd-package = { version = "0.5.0-beta.1", path = "crates/rd2qmd-package" }
-rd2qmd-source = { version = "0.5.0-beta.1", path = "crates/rd2qmd-source" }
+rd2qmd-mdast = { version = "0.5.0", path = "crates/rd2qmd-mdast" }
+rd2qmd-core = { version = "0.5.0", path = "crates/rd2qmd-core" }
+rd2qmd-package = { version = "0.5.0", path = "crates/rd2qmd-package" }
+rd2qmd-source = { version = "0.5.0", path = "crates/rd2qmd-source" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.5.0-beta.1 to 0.5.0
- Update `rd-ast` and `rd-source` dependencies from `=0.1.0-rc.1` to `0.1.0` (stable release now published; version pin removed)
- Finalize CHANGELOG `[Unreleased]` section as `[0.5.0] - 2026-07-26`

## Changelog

## [0.5.0] - 2026-07-26

### Changed

- **Breaking:** Migrate Rd parsing from the in-tree `rd-parser` crate to `rd-ast`/`rd-source` from the [r-documentation-rs](https://github.com/eitsupi/r-documentation-rs) (#50):
  - `rd2qmd-core`'s public API now operates directly on `rd_ast::RdDocument` (`convert_rd_document`, `rd_to_mdast`); the previous `RdConverter`/`convert_rd_content` API and all `rd_parser` re-exports are removed.
  - Bump the AST JSON envelope format version from 1 to 2 to match the new document shape.
  - Remove the `lifecycle` and `roxygen` Cargo library feature flags; roxygen2 fenced-code-block detection is now always enabled.
- Update the `rd-ast` and `rd-source` dependencies to `0.1.0`.
- Recoverable parser diagnostics are now surfaced end-to-end through the CLI, package converter, and topic index instead of being silently dropped. (#50)

### Added

- Add `RdConvertOptions::source_files_override` so library callers converting an externally produced `RdAstEnvelope` can preserve its authoritative `source_files` instead of having it silently re-derived from the AST. (#50)

### Fixed

- Collapse excessive prose spaces introduced at Rd AST node boundaries, so adjacent inline content no longer produces doubled-up whitespace in generated output. (#55)
- Ignore RDS `USERMACRO` definition metadata when converting inline nodes, preventing duplicated macro metadata in generated help output. (#52)
- Complete uniform suppression of the duplicate Rd title heading when YAML frontmatter is enabled across all output formats. (#49)
- Preserve special-character macros, encoded text, and link/S4-class/DOI display text when extracting frontmatter metadata. (#49)
- Enable a TLS backend for `reqwest` so external link resolution can actually fetch HTTPS `pkgdown.yml` sites instead of silently failing. (#49)
- Escape inline code spans that start with `r` plus whitespace so Quarto's knitr engine doesn't misinterpret literal code as executable inline R. (#49)
- Fix several conversion bugs found during the rd-parser migration review (#50):
  - Table-cell/equation whitespace handling now collapses only line endings, preserving intentional same-line spacing and ASCII-equation layout.
  - Link/image destinations containing whitespace, control characters, angle brackets, or parentheses are now wrapped in `<...>` for valid CommonMark; titles have line endings flattened and quotes/backslashes escaped.
  - `\tabular`, `\describe`, and `\preformatted` content nested inside `\arguments` is no longer silently dropped under the grid-table/pipe-table formats, and a list item's later block children are no longer dropped.
  - Pipe characters in table cells (including tables and definition lists nested inside `\arguments`) are now escaped correctly instead of being corrupted.
  - `\method`/`\S3method`/`\S4method` appearing outside `\usage` now render as their bare generic call instead of being silently dropped.