### PR TITLE
fix: indent block elements nested in definition lists and list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Indent every line of a block element nested in a `\describe{}` item, not just its first line. Code block bodies and closing fences were emitted at column 0, which terminated the definition list under strict CommonMark parsers.
+- Start a block element nested in an `\itemize{}` item on its own line instead of appending it to the preceding paragraph text.
+
 ## [0.5.0] - 2026-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Indent every line of a block element nested in a `\describe{}` item, not just its first line. Code block bodies and closing fences were emitted at column 0, which terminated the definition list under strict CommonMark parsers.
 - Start a block element nested in an `\itemize{}` item on its own line instead of appending it to the preceding paragraph text.
+- Derive a list item's continuation indent from its actual marker width. A fixed two-space assumption under-indented block elements in `\enumerate{}` items, letting them escape the item.
 
 ## [0.5.0] - 2026-07-26
 

--- a/crates/rd2qmd-cli/tests/fixtures/describe_code_blocks.Rd
+++ b/crates/rd2qmd-cli/tests/fixtures/describe_code_blocks.Rd
@@ -5,8 +5,9 @@
 Demonstrates the Pandoc definition-list writer's handling of multi-line
 block children -- roxygen2 fenced code blocks, a nested definition list,
 and a bulleted list item that itself contains a fenced code block --
-inside definition-list item descriptions. This is the ggproto/R6-style
-layout that roxygen2 commonly emits for methods and fields.
+inside definition-list item descriptions. Rd authors reach this layout by
+embedding raw markup in a free-text roxygen2 field, as ggplot2 does when
+documenting its extensible base classes.
 }
 \section{Methods}{
 \describe{

--- a/crates/rd2qmd-cli/tests/fixtures/describe_code_blocks.Rd
+++ b/crates/rd2qmd-cli/tests/fixtures/describe_code_blocks.Rd
@@ -1,0 +1,39 @@
+\name{describe_code_blocks}
+\alias{describe_code_blocks}
+\title{Describe Blocks With Roxygen Code Fences}
+\description{
+Demonstrates the Pandoc definition-list writer's handling of multi-line
+block children -- roxygen2 fenced code blocks, a nested definition list,
+and a bulleted list item that itself contains a fenced code block --
+inside definition-list item descriptions. This is the ggproto/R6-style
+layout that roxygen2 commonly emits for methods and fields.
+}
+\section{Methods}{
+\describe{
+\item{\code{compute()}}{\strong{Usage}
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{compute(a, b)
+compute(a, b, extra = TRUE)
+combine(a, b)
+}\if{html}{\out{</div>}}
+
+\strong{Arguments}
+\describe{
+\item{\code{a}}{The first value.}
+\item{\code{b}}{The second value.}
+}
+
+\strong{Examples}
+
+\itemize{
+\item Basic usage:
+
+\preformatted{compute(1, 2)
+#> [1] 3
+}
+\item Advanced usage returns invisibly.
+}
+
+That covers the \code{compute()} method.}
+}
+}

--- a/crates/rd2qmd-cli/tests/fixtures/describe_code_blocks.Rd
+++ b/crates/rd2qmd-cli/tests/fixtures/describe_code_blocks.Rd
@@ -34,6 +34,17 @@ combine(a, b)
 \item Advanced usage returns invisibly.
 }
 
+\strong{Ordered examples}
+
+\enumerate{
+\item Basic usage:
+
+\preformatted{compute(1, 2)
+#> [1] 3
+}
+\item Advanced usage returns invisibly.
+}
+
 That covers the \code{compute()} method.}
 }
 }

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -312,7 +312,8 @@ fn test_roxygen_code_blocks() {
 /// a roxygen2 fenced code block (`\if{html}{\out{<div ...>}}\preformatted{...}\if{html}{\out{</div>}}`),
 /// a nested `\describe{}` (the `\strong{Arguments}` pattern), and an
 /// `\itemize{}` whose item itself contains a `\preformatted{}` block --
-/// the ggproto/R6-style layout roxygen2 commonly emits. Regression coverage
+/// the layout Rd authors reach by embedding raw markup in a free-text
+/// roxygen2 field, as ggplot2 does for its base classes. Regression coverage
 /// for continuation-line indentation in the Pandoc definition-list writer:
 /// every fence/body/closing-fence line of a block child must be indented,
 /// not just the opening fence.

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -308,6 +308,20 @@ fn test_roxygen_code_blocks() {
     insta::assert_snapshot!("roxygen_code_blocks_qmd", output);
 }
 
+/// `\describe{}` item descriptions containing multi-line block children --
+/// a roxygen2 fenced code block (`\if{html}{\out{<div ...>}}\preformatted{...}\if{html}{\out{</div>}}`),
+/// a nested `\describe{}` (the `\strong{Arguments}` pattern), and an
+/// `\itemize{}` whose item itself contains a `\preformatted{}` block --
+/// the ggproto/R6-style layout roxygen2 commonly emits. Regression coverage
+/// for continuation-line indentation in the Pandoc definition-list writer:
+/// every fence/body/closing-fence line of a block child must be indented,
+/// not just the opening fence.
+#[test]
+fn test_describe_code_blocks() {
+    let output = convert_fixture("describe_code_blocks", &["--no-frontmatter"]);
+    insta::assert_snapshot!("describe_code_blocks_qmd", output);
+}
+
 #[test]
 fn test_directory_conversion() {
     let fixtures = fixtures_dir();

--- a/crates/rd2qmd-cli/tests/snapshots/integration__describe_code_blocks_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__describe_code_blocks_qmd.snap
@@ -6,7 +6,7 @@ expression: output
 
 ## Description
 
-Demonstrates the Pandoc definition-list writer's handling of multi-line block children -- roxygen2 fenced code blocks, a nested definition list, and a bulleted list item that itself contains a fenced code block -- inside definition-list item descriptions. This is the ggproto/R6-style layout that roxygen2 commonly emits for methods and fields.
+Demonstrates the Pandoc definition-list writer's handling of multi-line block children -- roxygen2 fenced code blocks, a nested definition list, and a bulleted list item that itself contains a fenced code block -- inside definition-list item descriptions. Rd authors reach this layout by embedding raw markup in a free-text roxygen2 field, as ggplot2 does when documenting its extensible base classes.
 
 ## Methods
 

--- a/crates/rd2qmd-cli/tests/snapshots/integration__describe_code_blocks_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__describe_code_blocks_qmd.snap
@@ -1,0 +1,41 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+# Describe Blocks With Roxygen Code Fences
+
+## Description
+
+Demonstrates the Pandoc definition-list writer's handling of multi-line block children -- roxygen2 fenced code blocks, a nested definition list, and a bulleted list item that itself contains a fenced code block -- inside definition-list item descriptions. This is the ggproto/R6-style layout that roxygen2 commonly emits for methods and fields.
+
+## Methods
+
+`compute()`
+:   **Usage**
+
+    ```r
+    compute(a, b)
+    compute(a, b, extra = TRUE)
+    combine(a, b)
+    ```
+
+    **Arguments**
+
+    `a`
+    :   The first value.
+
+    `b`
+    :   The second value.
+
+
+    **Examples**
+
+    - Basic usage:
+
+      ```
+      compute(1, 2)
+      #> [1] 3
+      ```
+    - Advanced usage returns invisibly.
+
+    That covers the `compute()` method.

--- a/crates/rd2qmd-cli/tests/snapshots/integration__describe_code_blocks_qmd.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__describe_code_blocks_qmd.snap
@@ -38,4 +38,14 @@ Demonstrates the Pandoc definition-list writer's handling of multi-line block ch
       ```
     - Advanced usage returns invisibly.
 
+    **Ordered examples**
+
+    1. Basic usage:
+
+       ```
+       compute(1, 2)
+       #> [1] 3
+       ```
+    2. Advanced usage returns invisibly.
+
     That covers the `compute()` method.

--- a/crates/rd2qmd-cli/tests/snapshots/integration__directory_files.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__directory_files.snap
@@ -4,6 +4,7 @@ expression: files
 ---
 - arguments_rich.qmd
 - conditionals.qmd
+- describe_code_blocks.qmd
 - example_control.qmd
 - examplesif.qmd
 - formatting.qmd

--- a/crates/rd2qmd-mdast/src/writer/block.rs
+++ b/crates/rd2qmd-mdast/src/writer/block.rs
@@ -291,19 +291,11 @@ impl<'a> Writer<'a> {
                                         self.output.push('\n');
                                         after_first = true;
                                     }
-                                    Node::Math(_) | Node::DefinitionList(_) => {
-                                        if after_first {
-                                            self.output.push_str("    ");
-                                        }
-                                        self.write_indented_definition_block(child, 4);
-                                        self.output.push('\n');
-                                        after_first = true;
-                                    }
                                     _ => {
                                         if after_first {
                                             self.output.push_str("    ");
                                         }
-                                        self.write_node(child);
+                                        self.write_reindented_block(child, 4);
                                         self.output.push('\n');
                                         after_first = true;
                                     }
@@ -338,7 +330,12 @@ impl<'a> Writer<'a> {
         self.at_line_start = true;
     }
 
-    fn write_indented_definition_block(&mut self, node: &Node, indent: usize) {
+    /// Render `node`, then re-indent every line after the first by `indent`
+    /// spaces. Used to keep multi-line block children (code fences, nested
+    /// lists, tables, ...) properly indented when nested inside a definition
+    /// description or a list item. The caller is responsible for indenting
+    /// the first line before calling this.
+    fn write_reindented_block(&mut self, node: &Node, indent: usize) {
         let indent_str = " ".repeat(indent);
         let start = self.output.len();
         self.write_node(node);
@@ -358,6 +355,7 @@ impl<'a> Writer<'a> {
 
     fn write_indented_list(&mut self, l: &crate::mdast::List, indent: usize) {
         let indent_str = " ".repeat(indent);
+        let item_indent_str = " ".repeat(indent + 2);
         let mut num = l.start.unwrap_or(1);
         for child in &l.children {
             if let Node::ListItem(li) = child {
@@ -369,19 +367,38 @@ impl<'a> Writer<'a> {
                     self.output.push_str("- ");
                 }
                 for (i, item_child) in li.children.iter().enumerate() {
-                    if i > 0 {
-                        self.output.push_str(&" ".repeat(indent + 2));
-                    }
                     match item_child {
                         Node::Paragraph(p) => {
+                            if i > 0 {
+                                self.output.push('\n');
+                                self.output.push('\n');
+                                self.output.push_str(&item_indent_str);
+                            }
                             for c in &p.children {
                                 self.write_node(c);
                             }
                         }
-                        _ => self.write_node(item_child),
+                        _ => {
+                            // Block children (code fences, nested lists, tables, ...) must
+                            // start on their own line, separated from preceding content by
+                            // a blank line, with every continuation line re-indented to
+                            // `indent + 2` so they stay inside the list item.
+                            self.output.push('\n');
+                            if i > 0 {
+                                self.output.push('\n');
+                            }
+                            self.output.push_str(&item_indent_str);
+                            self.write_reindented_block(item_child, indent + 2);
+                        }
                     }
                 }
-                self.output.push('\n');
+                // Block children (e.g. a code fence) already end with their own
+                // trailing newline; avoid stacking a second one here, which would
+                // otherwise turn into a spurious extra blank line once the caller
+                // (e.g. write_definition_list) adds its own separator newline.
+                if !self.output.ends_with('\n') {
+                    self.output.push('\n');
+                }
             }
         }
     }

--- a/crates/rd2qmd-mdast/src/writer/block.rs
+++ b/crates/rd2qmd-mdast/src/writer/block.rs
@@ -355,17 +355,23 @@ impl<'a> Writer<'a> {
 
     fn write_indented_list(&mut self, l: &crate::mdast::List, indent: usize) {
         let indent_str = " ".repeat(indent);
-        let item_indent_str = " ".repeat(indent + 2);
         let mut num = l.start.unwrap_or(1);
         for child in &l.children {
             if let Node::ListItem(li) = child {
                 self.output.push_str(&indent_str);
-                if l.ordered {
-                    self.output.push_str(&format!("{}. ", num));
+                // Build the marker first so item_indent matches the actual marker width.
+                // "- " is always 2 chars, but "10. " is 4 — a fixed +2 would mis-indent
+                // continuation lines for ordered lists with wide numbers.
+                let marker = if l.ordered {
+                    let m = format!("{}. ", num);
                     num += 1;
+                    m
                 } else {
-                    self.output.push_str("- ");
-                }
+                    "- ".to_string()
+                };
+                self.output.push_str(&marker);
+                let item_indent = indent + marker.len();
+                let item_indent_str = " ".repeat(item_indent);
                 for (i, item_child) in li.children.iter().enumerate() {
                     match item_child {
                         Node::Paragraph(p) => {
@@ -382,13 +388,13 @@ impl<'a> Writer<'a> {
                             // Block children (code fences, nested lists, tables, ...) must
                             // start on their own line, separated from preceding content by
                             // a blank line, with every continuation line re-indented to
-                            // `indent + 2` so they stay inside the list item.
+                            // `item_indent` so they stay inside the list item.
                             self.output.push('\n');
                             if i > 0 {
                                 self.output.push('\n');
                             }
                             self.output.push_str(&item_indent_str);
-                            self.write_reindented_block(item_child, indent + 2);
+                            self.write_reindented_block(item_child, item_indent);
                         }
                     }
                 }

--- a/crates/rd2qmd-mdast/src/writer/tests.rs
+++ b/crates/rd2qmd-mdast/src/writer/tests.rs
@@ -534,6 +534,52 @@ fn test_definition_list_nested_list_code_block_indent() {
 }
 
 #[test]
+fn test_definition_list_ordered_list_code_block_indent() {
+    // A code block inside an ORDERED list item, where that list is itself
+    // inside a definition description, must be indented by `indent + 3`
+    // (the width of "1. "), not the unordered-list width of `indent + 2`.
+    let root = Root::new(vec![Node::definition_list(vec![
+        Node::definition_term(vec![Node::text("Term")]),
+        Node::definition_description(vec![Node::list(
+            true,
+            vec![Node::list_item(vec![
+                Node::paragraph(vec![Node::text("First item")]),
+                Node::code(Some("r".to_string()), "code_in_list(1)\ncode_in_list(2)"),
+            ])],
+        )]),
+    ])]);
+    let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+    assert!(
+        qmd.contains(
+            "1. First item\n\n       ```r\n       code_in_list(1)\n       code_in_list(2)\n       ```"
+        ),
+        "code block not indented by indent+3 for ordered marker; got: {qmd:?}"
+    );
+}
+
+#[test]
+fn test_definition_list_ordered_list_ten_items_code_block_indent() {
+    // Once the list reaches item 10, the marker becomes "10. " (4 chars),
+    // so the continuation indent must widen accordingly for that item.
+    let mut items: Vec<Node> = (1..=9)
+        .map(|i| Node::list_item(vec![Node::paragraph(vec![Node::text(format!("Item {i}"))])]))
+        .collect();
+    items.push(Node::list_item(vec![
+        Node::paragraph(vec![Node::text("Item 10")]),
+        Node::code(Some("r".to_string()), "tenth(1)"),
+    ]));
+    let root = Root::new(vec![Node::definition_list(vec![
+        Node::definition_term(vec![Node::text("Term")]),
+        Node::definition_description(vec![Node::list(true, items)]),
+    ])]);
+    let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+    assert!(
+        qmd.contains("10. Item 10\n\n        ```r\n        tenth(1)\n        ```"),
+        "code block not indented by indent+4 for '10. ' marker; got: {qmd:?}"
+    );
+}
+
+#[test]
 fn test_table() {
     let root = Root::new(vec![Node::table(
         vec![Some(Align::Left), Some(Align::Right)],

--- a/crates/rd2qmd-mdast/src/writer/tests.rs
+++ b/crates/rd2qmd-mdast/src/writer/tests.rs
@@ -487,6 +487,53 @@ fn test_loose_list_block_child_continuation_indent() {
 }
 
 #[test]
+fn test_definition_list_code_block_continuation_indent() {
+    // A code block inside a definition description must have every line
+    // (opening fence, body, closing fence) indented by 4 spaces, not just
+    // the opening fence.
+    let root = Root::new(vec![Node::definition_list(vec![
+        Node::definition_term(vec![Node::text("Term")]),
+        Node::definition_description(vec![
+            Node::paragraph(vec![Node::text("Intro")]),
+            Node::code(Some("r".to_string()), "x <- 1\ny <- 2"),
+        ]),
+    ])]);
+    let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+    assert!(
+        qmd.contains("    ```r\n    x <- 1\n    y <- 2\n    ```"),
+        "code block continuation lines not indented by 4; got: {qmd:?}"
+    );
+}
+
+#[test]
+fn test_definition_list_nested_list_code_block_indent() {
+    // A code block inside a list item, where that list is itself inside a
+    // definition description, must start on its own line (not glued to the
+    // preceding item text) and have every line indented by `indent + 2`.
+    let root = Root::new(vec![Node::definition_list(vec![
+        Node::definition_term(vec![Node::text("Term")]),
+        Node::definition_description(vec![Node::list(
+            false,
+            vec![Node::list_item(vec![
+                Node::paragraph(vec![Node::text("First item")]),
+                Node::code(Some("r".to_string()), "code_in_list(1)\ncode_in_list(2)"),
+            ])],
+        )]),
+    ])]);
+    let qmd = mdast_to_qmd(&root, &WriterOptions::default());
+    assert!(
+        !qmd.contains("First item      ```"),
+        "code fence glued onto preceding item text; got: {qmd:?}"
+    );
+    assert!(
+        qmd.contains(
+            "- First item\n\n      ```r\n      code_in_list(1)\n      code_in_list(2)\n      ```"
+        ),
+        "code block not on its own line / not indented by indent+2; got: {qmd:?}"
+    );
+}
+
+#[test]
 fn test_table() {
     let root = Root::new(vec![Node::table(
         vec![Some(Align::Left), Some(Align::Right)],


### PR DESCRIPTION
Code blocks inside `\describe{}` items were emitted with their opening fence indented but their body lines and closing fence at column 0:

````
`setup_params`
:   **Usage**

    ```r
Facet$setup_params(data, params)
```
````

Pandoc's `markdown` reader tolerates this, so `quarto render` looked fine. Strict CommonMark parsers (GitHub, VS Code preview) do not — the definition item is terminated, the code becomes a paragraph, and the remainder collapses into an indented code block. Converting ggplot2's `Facet.Rd` and running the result through `pandoc -f commonmark_x` yields 11 `<dd>` elements instead of 93.

Not a regression from the parser migration. Before it, the `\preformatted{}` blocks and nested `\describe{}` were dropped entirely and the paragraphs collapsed onto one line, so this content was never rendered correctly.

## Affected input

Any `\describe{}` whose item bodies contain block content — a code block, a nested `\describe{}`, or a list holding a code block.

Authors reach this by embedding raw Rd markup inside a free-text roxygen2 field rather than through any automatic mechanism, so it is uncommon but not rare. A scan of 1,438 `.Rd` files across the R packages I had available found 9 hits, all of them ggplot2's extensible base classes: `Coord`, `Facet`, `Geom`, `Guide`, `Layer-class`, `Layout`, `Position`, `Scale`, `Stat`. Nothing else matched. Notably roxygen2's own R6 output is *not* affected — it keeps method code in sibling `\subsection{}` blocks rather than inside `\describe{}` item bodies.

## Changes

The definition-list writer routed only `Math` and nested `DefinitionList` children through its capture-and-reindent helper; everything else, including code blocks, went through `write_node` unmodified. All block children now go through the helper, which is renamed `write_reindented_block` since it is no longer definition-list specific.

The same helper now backs list items, where a block child was additionally being appended to the preceding paragraph text instead of starting on its own line.

A related defect found in review: `write_indented_list` assumed a two-space marker when computing continuation indent. That holds for `- ` but not for `1. ` or `10. `, so block elements inside `\enumerate{}` items were indented short and escaped the item. The marker is now built before the indent is derived, matching what `write_list_at_indent` already does for top-level lists.

## Tests

- Four unit tests in the writer, covering a code block directly in a definition description, one inside a nested unordered list, and ordered lists with 3- and 4-character markers. All four were confirmed to fail against the unfixed code.
- A new CLI snapshot fixture reproducing the affected layout: roxygen fenced code block, nested `\describe{}`, and `\itemize{}`/`\enumerate{}` items containing their own code blocks.

## Follow-ups

Three pre-existing defects were found during this work and left out of scope, each tracked separately: a double blank line after a nested `\describe{}`, missing quote markers on multi-line blockquote children, and the inconsistent trailing-newline contract among the block writers that underlies both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)