### PR TITLE
chore: prepare release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-31
+
 ### Fixed
 
-- Indent every line of a block element nested in a `\describe{}` item, not just its first line. Code block bodies and closing fences were emitted at column 0, which terminated the definition list under strict CommonMark parsers.
-- Start a block element nested in an `\itemize{}` item on its own line instead of appending it to the preceding paragraph text.
-- Derive a list item's continuation indent from its actual marker width. A fixed two-space assumption under-indented block elements in `\enumerate{}` items, letting them escape the item.
+- Indent every line of a block element nested in a `\describe{}` item, not just its first line. Code block bodies and closing fences were emitted at column 0, which terminated the definition list under strict CommonMark parsers. (#62)
+- Start a block element nested in an `\itemize{}` item on its own line instead of appending it to the preceding paragraph text. (#62)
+- Derive a list item's continuation indent from its actual marker width. A fixed two-space assumption under-indented block elements in `\enumerate{}` items, letting them escape the item. (#62)
 
 ## [0.5.0] - 2026-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "insta",
  "rd-ast",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "insta",
  "serde",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-package"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "r-description",
  "rayon",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-source"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "rd-ast",
  "rd-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/rd2qmd-cli"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -47,10 +47,10 @@ rd-source = "0.1.0"
 insta = { version = "1", features = ["yaml"] }
 
 # Internal crates
-rd2qmd-mdast = { version = "0.5.0", path = "crates/rd2qmd-mdast" }
-rd2qmd-core = { version = "0.5.0", path = "crates/rd2qmd-core" }
-rd2qmd-package = { version = "0.5.0", path = "crates/rd2qmd-package" }
-rd2qmd-source = { version = "0.5.0", path = "crates/rd2qmd-source" }
+rd2qmd-mdast = { version = "0.5.1", path = "crates/rd2qmd-mdast" }
+rd2qmd-core = { version = "0.5.1", path = "crates/rd2qmd-core" }
+rd2qmd-package = { version = "0.5.1", path = "crates/rd2qmd-package" }
+rd2qmd-source = { version = "0.5.1", path = "crates/rd2qmd-source" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.5.0 to 0.5.1
- Finalize CHANGELOG `[Unreleased]` section as `[0.5.1] - 2026-07-31`

## Changelog

## [0.5.1] - 2026-07-31

### Fixed

- Indent every line of a block element nested in a `\describe{}` item, not just its first line. Code block bodies and closing fences were emitted at column 0, which terminated the definition list under strict CommonMark parsers. (#62)
- Start a block element nested in an `\itemize{}` item on its own line instead of appending it to the preceding paragraph text. (#62)
- Derive a list item's continuation indent from its actual marker width. A fixed two-space assumption under-indented block elements in `\enumerate{}` items, letting them escape the item. (#62)