### PR TITLE
chore: update rd-ast/rd-source to 0.3.1 without default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update the `rd-ast` and `rd-source` dependencies to `0.3.1`, and disable `rd-ast`'s default features so that the optional compression codecs (and their `liblzma` link) can never be pulled into the dependency graph.
+
 ## [0.5.1] - 2026-07-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,18 +1165,18 @@ dependencies = [
 
 [[package]]
 name = "rd-ast"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd34b9f48d1d7e4b54fcb38e191460edaac7bcef76685235394649868e7c728"
+checksum = "1271da631b9dbdeac3d23e1666c066164ec8eb620cb8504310a0bcd9948b4c0b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rd-source"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498b9c8e7c53b728a85178ca0dcf37c432c108f104bf236d743cd0a33be3a85f"
+checksum = "7820ec265c6daf795863a24a14f648b40f2f70327e641f404b3927047693dc13"
 dependencies = [
  "rd-ast",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ reqwest = { version = "0.13", features = ["blocking", "rustls"], default-feature
 url = "2"
 
 # R documentation AST and source parser
-rd-ast = { version = "0.1.0", features = ["serde"] }
-rd-source = "0.1.0"
+rd-ast = { version = "0.3.1", default-features = false, features = ["serde"] }
+rd-source = "0.3.1"
 
 # Testing
 insta = { version = "1", features = ["yaml"] }


### PR DESCRIPTION
Update `rd-ast` / `rd-source` from `0.1.0` to `0.3.1`, and declare `rd-ast` with
`default-features = false`.

```toml
rd-ast = { version = "0.3.1", default-features = false, features = ["serde"] }
rd-source = "0.3.1"
```

## Why

[r-documentation-rs 0.3.1](https://github.com/eitsupi/r-documentation-rs) reworked
how the compression codec features are forwarded to `rd-rds`. Before that release,
`rd-ast` and `rd-helpdb` depended on `rd-rds` with default features always on, so
Cargo's feature unification made it impossible for downstream crates to escape the
`xz` codec — which links `liblzma` dynamically and breaks binaries on macOS
(see eitsupi/arf#302).

`rd2qmd` needs only `rd-ast`'s `serde` feature and uses none of `rd-rds`,
`rd-writer`, or `rd-helpdb`. Declaring the dependency with `default-features = false`
states that explicitly and keeps the codec chain permanently out of the graph,
independent of how upstream defines its defaults in the future.

## Notes

- No source changes and no snapshot changes were required. `rd-ast` and `rd-source`
  had no breaking public API changes between `0.1.0` and `0.3.1`; the breaking change
  in `0.3.0` was confined to `rd-writer`, which this project does not depend on.
- The `0.2.0` parser fixes (raw strings, backslash-newline escapes) did not alter any
  existing fixture output.
- Verified that `xz2`, `lzma-sys`, `rd-rds`, `rd-helpdb`, and `rd-writer` are all
  absent from the dependency graph, including under `--all-features`.
- The `Cargo.lock` diff is limited to the two upgraded packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
