### PR TITLE
chore: prepare release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-12
+
 ### Changed
 
-- Update the `rd-ast` and `rd-source` dependencies to `0.3.1`, and disable `rd-ast`'s default features so that the optional compression codecs (and their `liblzma` link) can never be pulled into the dependency graph.
+- Update the `rd-ast` and `rd-source` dependencies to `0.3.1`, and disable `rd-ast`'s default features so that the optional compression codecs (and their `liblzma` link) can never be pulled into the dependency graph. (#69)
 
 ## [0.5.1] - 2026-07-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "rd-ast",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-mdast"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "insta",
  "serde",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-package"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "r-description",
  "rayon",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "rd2qmd-source"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "rd-ast",
  "rd-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/rd2qmd-cli"]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT"
@@ -47,10 +47,10 @@ rd-source = "0.3.1"
 insta = { version = "1", features = ["yaml"] }
 
 # Internal crates
-rd2qmd-mdast = { version = "0.5.1", path = "crates/rd2qmd-mdast" }
-rd2qmd-core = { version = "0.5.1", path = "crates/rd2qmd-core" }
-rd2qmd-package = { version = "0.5.1", path = "crates/rd2qmd-package" }
-rd2qmd-source = { version = "0.5.1", path = "crates/rd2qmd-source" }
+rd2qmd-mdast = { version = "0.5.2", path = "crates/rd2qmd-mdast" }
+rd2qmd-core = { version = "0.5.2", path = "crates/rd2qmd-core" }
+rd2qmd-package = { version = "0.5.2", path = "crates/rd2qmd-package" }
+rd2qmd-source = { version = "0.5.2", path = "crates/rd2qmd-source" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.5.1 to 0.5.2, including the internal crate version references in `[workspace.dependencies]`
- Finalize CHANGELOG `[Unreleased]` section as `[0.5.2] - 2026-08-12` and open a fresh `[Unreleased]` section

No snapshot updates were required for this release.

## Changelog

### Changed

- Update the `rd-ast` and `rd-source` dependencies to `0.3.1`, and disable `rd-ast`'s default features so that the optional compression codecs (and their `liblzma` link) can never be pulled into the dependency graph. (#69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
