### PR TITLE
[WIP] add a Typst output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Typst output format (`-f typ`, config `output.format = "typ"`). The generated `.typ` compiles to PDF with `typst compile`, and to HTML with Typst 0.15's `--features html --format html` export target. Rd LaTeX equations go through [MiTeX](https://typst.app/universe/package/mitex/) (`#mi`/`#mitex`, imported only by documents that contain math), `\out{}` fragments become `html.elem` calls guarded by `target()` so PDF compilation still works, and R code is emitted as plain ```` ```r ```` raw blocks — highlighted listings under plain `typst`, executable under [calepin](https://vincentarelbundock.github.io/calepin/).
+
+### Changed
+
+- The Arguments section is now carried through the pipeline as a semantic `Arguments` mdast node instead of a pre-rendered Markdown string, and `--arguments-format` is applied by the writer rather than during conversion. Markdown output is unchanged; the new Typst writer renders the same node as a `#table` (or `#terms` for `--arguments-format list`). Pipe-table cell escaping for `\tabular{}` likewise moved to the Markdown writer, so no Markdown syntax is produced during Rd conversion any more.
+
 ## [0.5.2] - 2026-08-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -548,6 +548,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html-escape"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "http"
@@ -1077,7 +1083,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1214,9 +1220,11 @@ dependencies = [
 name = "rd2qmd-mdast"
 version = "0.5.2"
 dependencies = [
+ "html-escape",
  "insta",
  "serde",
  "serde_json",
+ "tabled",
 ]
 
 [[package]]
@@ -1388,7 +1396,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1445,7 +1453,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1760,7 +1768,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2171,7 +2179,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ schemars = "1"
 
 # Table generation (for Grid Tables)
 tabled = { version = "0.21", default-features = false, features = ["std"] }
+html-escape = "0.2"
 
 # External link resolution (optional)
 r-description = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A fast Rd-to-Quarto Markdown converter written in Rust, with intelligent link re
 - **Quarto-ready**: Generates `.qmd` files with `{r}` executable code blocks and YAML frontmatter
 - **Flexible Arguments format**: Supports Quarto native List-Tables (default), Pandoc Grid Tables, GFM Pipe Tables, and Markdown loose lists for the Arguments section (`--arguments-format list-table|grid-table|pipe-table|list`)
 - **pkgdown-compatible metadata**: Adds `pagetitle` in pkgdown style (`"<title> — <name>"`) for SEO
+- **Typst output**: Emits `.typ` markup (`-f typ`) that compiles to PDF or, via Typst 0.15 HTML export, to HTML — with MiTeX for Rd LaTeX equations, `html.elem` for `\out{}` fragments, and plain ```` ```r ```` blocks that [calepin](https://vincentarelbundock.github.io/calepin/) can execute
 - **No R required**: Pure Rust binary with no runtime R dependency
 
 ## Installation
@@ -41,7 +42,7 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/eitsupi/rd2qmd/rel
 
 rd2qmd provides four subcommands:
 
-- `convert` — convert Rd files to Quarto Markdown, R Markdown, or standard Markdown
+- `convert` — convert Rd files to Quarto Markdown, R Markdown, standard Markdown, or Typst
 - `parse` — parse Rd files to AST JSON (see [AST JSON I/O](#ast-json-io))
 - `index` — generate a JSON topic index (see [Topic index generation](#topic-index-generation))
 - `init` — create a starter `_rd2qmd.toml` configuration file
@@ -59,6 +60,9 @@ rd2qmd convert file.Rd -o output.qmd
 
 # Convert to standard Markdown instead of Quarto
 rd2qmd convert file.Rd -f md
+
+# Convert to Typst
+rd2qmd convert file.Rd -f typ
 ```
 
 ### Directory conversion
@@ -81,7 +85,7 @@ rd2qmd convert man/ -o docs/ -j4
 | Option | Description |
 |--------|-------------|
 | `-o, --output <PATH>` | Output file or directory |
-| `-f, --format <FORMAT>` | Output format: `qmd` (default), `md`, or `rmd` |
+| `-f, --format <FORMAT>` | Output format: `qmd` (default), `md`, `rmd`, or `typ` |
 | `-j, --jobs <N>` | Number of parallel jobs (defaults to CPU count) |
 | `-r, --recursive` | Process directories recursively |
 | `--no-frontmatter` | Disable YAML frontmatter; use this for a visible body `# Title` in Markdown consumers that do not render YAML titles |
@@ -328,6 +332,51 @@ Use `-f md` for standard markdown with:
 - Internal links resolved to `.md` files
 
 Unlike Quarto, not all `.md` consumers render a YAML frontmatter title as a visible heading; use `--no-frontmatter` when portability requires a body heading.
+
+### Typst (`.typ`)
+
+Use `-f typ` for [Typst](https://typst.app) markup, which compiles to PDF with
+`typst compile`, and to HTML with Typst 0.15's export target
+(`typst compile --features html --format html`). Output uses:
+
+- `#set document(title: ..)` plus a queryable `#metadata((..))<rd2qmd>` block
+  and a visible `= Title` heading, in place of YAML frontmatter
+- Plain ```` ```r ```` raw blocks — Typst has no executable code blocks, so
+  under plain `typst` these render as highlighted listings, while
+  [calepin](https://vincentarelbundock.github.io/calepin/) can execute the
+  very same blocks
+- `#table` for the Arguments section and `\tabular{}`, `#terms` for
+  `\describe{}`, `#link` for links
+- Internal links resolved to `.typ` files
+
+Two Rd constructs need translation rather than a direct mapping:
+
+**Equations.** Rd equation bodies are LaTeX, which Typst's own math mode does
+not read, so `\eqn`/`\deqn` are emitted as [MiTeX](https://typst.app/universe/package/mitex/)
+calls (`#mi` inline, `#mitex` for display). The import line is added only to
+documents that actually contain math, so packages without equations need no
+Typst packages at all. `--prefer-ascii-math` still applies and avoids MiTeX
+entirely where an ASCII representation exists.
+
+**Raw HTML.** `\out{}` content is re-expressed with Typst 0.15's
+[`html.elem`](https://typst.app/docs/reference/html/elem/), guarded by
+`target()` so the same file still compiles to PDF:
+
+```typst
+#context { if target() == "html" { html.elem("sup")[2] } }
+```
+
+A fragment too involved to express as one element (nested tags, several
+siblings) is kept verbatim as `#raw(..)` rather than dropped.
+
+One caveat: `\figure{}` becomes `#image("file.png")`, and Typst *errors* on a
+missing image file where Markdown renderers merely show a broken image. Copy
+the package's `man/figures/` alongside the output before compiling.
+
+`--arguments-format` still applies, but Typst's table holds arbitrary block
+content, so the three table variants (`list-table`, `grid-table`,
+`pipe-table` — all Markdown workarounds) produce the same `#table`. Only
+`list` differs: it renders `#terms` instead.
 
 ### Arguments format
 

--- a/crates/rd2qmd-cli/examples/benchmark.rs
+++ b/crates/rd2qmd-cli/examples/benchmark.rs
@@ -201,6 +201,7 @@ fn run_single_benchmark(
         include_internal: false, // skip internal topics by default
         include_html_output: false,
         prefer_ascii_math: false,
+        target: rd2qmd_core::OutputTarget::default(),
         arguments_format: rd2qmd_core::ArgumentsFormat::default(),
     };
 

--- a/crates/rd2qmd-cli/schema/rd2qmd.schema.json
+++ b/crates/rd2qmd-cli/schema/rd2qmd.schema.json
@@ -157,7 +157,7 @@
           ]
         },
         "format": {
-          "description": "Output format: \"qmd\" (Quarto Markdown), \"md\" (standard Markdown), or \"rmd\" (R Markdown)",
+          "description": "Output format: \"qmd\" (Quarto Markdown), \"md\" (standard Markdown), \"rmd\" (R Markdown), or \"typ\" (Typst)",
           "type": [
             "string",
             "null"

--- a/crates/rd2qmd-cli/src/cli.rs
+++ b/crates/rd2qmd-cli/src/cli.rs
@@ -14,7 +14,19 @@ pub(crate) struct ExternalLinkOptions {
 }
 
 /// Output format for markdown conversion
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Deserialize,
+    serde::Serialize,
+    schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
 pub(crate) enum OutputFormat {
     /// Quarto Markdown (.qmd) - uses {r} code blocks for examples
     #[default]
@@ -23,6 +35,9 @@ pub(crate) enum OutputFormat {
     Md,
     /// R Markdown (.Rmd) - uses {r} code blocks for examples
     Rmd,
+    /// Typst (.typ) - plain ```r raw blocks, MiTeX math, executable with calepin
+    #[serde(alias = "typst")]
+    Typ,
 }
 
 /// Input format for Rd documentation

--- a/crates/rd2qmd-cli/src/commands/convert.rs
+++ b/crates/rd2qmd-cli/src/commands/convert.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
+use rd2qmd_core::OutputTarget;
 use rd2qmd_core::{
     ArgumentsFormat, CodeExecutionOptions, FrontmatterOptions, LinkOptions, RdAstEnvelope,
     RdConvertOptions, convert_rd_document,
@@ -43,6 +44,12 @@ pub(crate) fn run_convert_command(args: &ConvertArgs, verbose: bool, quiet: bool
         OutputFormat::Qmd => "qmd",
         OutputFormat::Md => "md",
         OutputFormat::Rmd => "Rmd",
+        OutputFormat::Typ => "typ",
+    };
+
+    let target = match format {
+        OutputFormat::Typ => OutputTarget::Typst,
+        _ => OutputTarget::Markdown,
     };
 
     // quarto_code_blocks: CLI > Config > auto (based on format)
@@ -101,6 +108,7 @@ pub(crate) fn run_convert_command(args: &ConvertArgs, verbose: bool, quiet: bool
             exec_donttest,
             include_html_output,
             prefer_ascii_math,
+            target,
             arguments_format,
             verbose,
             quiet,
@@ -129,6 +137,7 @@ pub(crate) fn run_convert_command(args: &ConvertArgs, verbose: bool, quiet: bool
             include_internal,
             include_html_output,
             prefer_ascii_math,
+            target,
             arguments_format,
             args.topic_index.as_deref(),
             verbose,
@@ -159,6 +168,7 @@ fn convert_single_file(
     exec_donttest: bool,
     include_html_output: bool,
     prefer_ascii_math: bool,
+    target: OutputTarget,
     arguments_format: ArgumentsFormat,
     verbose: bool,
     quiet: bool,
@@ -205,6 +215,7 @@ fn convert_single_file(
                 alias_map: None,
                 package_urls,
             },
+            target,
             arguments_format,
             include_html_output,
             prefer_ascii_math,
@@ -244,6 +255,7 @@ fn convert_single_file(
                 alias_map: None,
                 package_urls,
             },
+            target,
             arguments_format,
             include_html_output,
             prefer_ascii_math,
@@ -288,6 +300,7 @@ fn convert_directory(
     include_internal: bool,
     include_html_output: bool,
     prefer_ascii_math: bool,
+    target: OutputTarget,
     arguments_format: ArgumentsFormat,
     topic_index_path: Option<&Path>,
     verbose: bool,
@@ -352,6 +365,7 @@ fn convert_directory(
         include_internal,
         include_html_output,
         prefer_ascii_math,
+        target,
         arguments_format,
     };
 

--- a/crates/rd2qmd-cli/src/commands/index.rs
+++ b/crates/rd2qmd-cli/src/commands/index.rs
@@ -17,6 +17,7 @@ pub(crate) fn run_index_command(args: &IndexArgs, quiet: bool) -> Result<()> {
         OutputFormat::Qmd => "qmd",
         OutputFormat::Md => "md",
         OutputFormat::Rmd => "Rmd",
+        OutputFormat::Typ => "typ",
     };
 
     let package = RdPackage::from_directory_with_format(

--- a/crates/rd2qmd-cli/src/config.rs
+++ b/crates/rd2qmd-cli/src/config.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::cli::OutputFormat;
+
 /// Output format for the Arguments section
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema, clap::ValueEnum,
@@ -53,9 +55,9 @@ pub struct Config {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(default)]
 pub struct OutputConfig {
-    /// Output format: "qmd" (Quarto Markdown), "md" (standard Markdown), or "rmd" (R Markdown)
+    /// Output format: "qmd" (Quarto Markdown), "md" (standard Markdown), "rmd" (R Markdown), or "typ" (Typst)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub format: Option<String>,
+    pub format: Option<OutputFormat>,
     /// Add YAML frontmatter with title (default: true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frontmatter: Option<bool>,
@@ -212,7 +214,7 @@ impl Config {
     pub fn sample() -> Self {
         Config {
             output: OutputConfig {
-                format: Some("qmd".to_string()),
+                format: Some(OutputFormat::Qmd),
                 frontmatter: Some(true),
                 pagetitle: Some(true),
                 arguments_format: Some(ArgumentsFormat::ListTable),
@@ -265,13 +267,23 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.output.format, Some("md".to_string()));
+        assert_eq!(config.output.format, Some(OutputFormat::Md));
         assert_eq!(config.output.frontmatter, Some(false));
         assert_eq!(config.output.pagetitle, Some(true));
         assert_eq!(
             config.output.arguments_format,
             Some(ArgumentsFormat::PipeTable)
         );
+    }
+
+    #[test]
+    fn test_output_format_rejects_typos_and_accepts_typst_alias() {
+        let error = toml::from_str::<Config>("[output]\nformat = \"typs\"\n")
+            .expect_err("an unknown output format must be rejected");
+        assert!(error.to_string().contains("unknown variant `typs`"));
+
+        let config: Config = toml::from_str("[output]\nformat = \"typst\"\n").unwrap();
+        assert_eq!(config.output.format, Some(OutputFormat::Typ));
     }
 
     #[test]
@@ -391,7 +403,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.output.format, Some("qmd".to_string()));
+        assert_eq!(config.output.format, Some(OutputFormat::Qmd));
         assert_eq!(config.external.enabled, Some(true));
     }
 
@@ -406,7 +418,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.output.format, Some("md".to_string()));
+        assert_eq!(config.output.format, Some(OutputFormat::Md));
         // Other sections should be default
         assert!(config.code.quarto_code_blocks.is_none());
         assert!(config.links.unqualified_link_url.is_none());

--- a/crates/rd2qmd-cli/src/config_merge.rs
+++ b/crates/rd2qmd-cli/src/config_merge.rs
@@ -37,15 +37,11 @@ pub(crate) fn load_config(args: &ConvertArgs) -> Result<Config> {
 /// This means config wins when CLI uses default (qmd).
 pub(crate) fn merge_format(args: &ConvertArgs, config: &Config) -> OutputFormat {
     // If config specifies a format, check if CLI is using the default
-    if let Some(ref fmt) = config.output.format {
+    if let Some(format) = config.output.format {
         // Only use config if CLI appears to be using default
         // This is a heuristic - we assume if CLI is Qmd (default), config should win
         if args.format == OutputFormat::Qmd {
-            return match fmt.to_lowercase().as_str() {
-                "md" => OutputFormat::Md,
-                "rmd" => OutputFormat::Rmd,
-                _ => OutputFormat::Qmd,
-            };
+            return format;
         }
     }
     args.format

--- a/crates/rd2qmd-cli/src/tests.rs
+++ b/crates/rd2qmd-cli/src/tests.rs
@@ -51,7 +51,7 @@ fn test_merge_format_config_overrides_default() {
     let cli = default_convert_args();
     let config = Config {
         output: config::OutputConfig {
-            format: Some("md".to_string()),
+            format: Some(OutputFormat::Md),
             ..Default::default()
         },
         ..Default::default()
@@ -65,7 +65,7 @@ fn test_merge_format_cli_overrides_config() {
     cli.format = OutputFormat::Rmd;
     let config = Config {
         output: config::OutputConfig {
-            format: Some("md".to_string()),
+            format: Some(OutputFormat::Md),
             ..Default::default()
         },
         ..Default::default()

--- a/crates/rd2qmd-cli/tests/integration.rs
+++ b/crates/rd2qmd-cli/tests/integration.rs
@@ -36,7 +36,13 @@ fn convert_fixture(name: &str, args: &[&str]) -> String {
     // Use a unique temp file for each invocation to avoid race conditions
     let unique_id = COUNTER.fetch_add(1, Ordering::SeqCst);
     let pid = std::process::id();
-    let ext = if args.contains(&"md") { "md" } else { "qmd" };
+    let ext = if args.contains(&"md") {
+        "md"
+    } else if args.contains(&"typ") {
+        "typ"
+    } else {
+        "qmd"
+    };
     let output = std::env::temp_dir().join(format!(
         "rd2qmd_test_{}_{}_{}_{}.{}",
         name,
@@ -978,4 +984,53 @@ fn test_index_empty_ast_directory_mentions_json_files() {
 
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("No .json files found"));
+}
+
+#[test]
+fn test_simple_to_typst() {
+    let output = convert_fixture("simple", &["-f", "typ"]);
+    insta::assert_snapshot!("simple_typ", output);
+}
+
+#[test]
+fn test_arguments_rich_to_typst() {
+    let output = convert_fixture("arguments_rich", &["-f", "typ"]);
+    insta::assert_snapshot!("arguments_rich_typ", output);
+}
+
+#[test]
+fn test_typst_directory_links_resolve_to_typ_files() {
+    let output_dir = unique_temp_dir("typst_dir");
+    fs::create_dir_all(&output_dir).expect("Failed to create output dir");
+
+    let status = Command::new(rd2qmd_binary())
+        .arg("convert")
+        .arg(fixtures_dir())
+        .arg("-o")
+        .arg(&output_dir)
+        .args(["-f", "typ", "-q", "--no-external-links"])
+        .status()
+        .expect("Failed to run rd2qmd");
+    assert!(status.success(), "rd2qmd directory conversion failed");
+
+    let converted = fs::read_to_string(output_dir.join("with_links.typ")).expect("with_links.typ");
+    // Alias-resolved internal links follow the output extension, like every
+    // other format.
+    assert!(
+        converted.contains("#link(\"simple.typ\")"),
+        "expected an internal link to a .typ file, got:\n{converted}"
+    );
+
+    let _ = fs::remove_dir_all(&output_dir);
+}
+
+#[test]
+fn test_typst_examples_are_plain_r_blocks() {
+    let output = convert_fixture("example_control", &["-f", "typ"]);
+    // Never `{r}`: calepin executes a plain raw block, plain typst renders it.
+    assert!(output.contains("```r\n"), "expected a plain ```r block");
+    assert!(
+        !output.contains("{r}"),
+        "expected no Quarto executable block"
+    );
 }

--- a/crates/rd2qmd-cli/tests/snapshots/integration__arguments_rich_typ.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__arguments_rich_typ.snap
@@ -1,0 +1,109 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+#set document(title: "Rich Argument Content")
+#metadata((
+  pagetitle: "Rich Argument Content — arguments_rich",
+  aliases: ("arguments_rich",),
+))<rd2qmd>
+
+= Rich Argument Content
+
+== Description
+
+This function has arguments with rich, nested Markdown-relevant content\.
+
+== Usage
+
+```r
+#| eval: false
+arguments_rich(x, method, describe_arg, table_arg, pre_only, pre_with_intro,
+  backtick_code, fence_collision, cr_break, multi_paragraph,
+  itemize_multi_paragraph, ...)
+```
+
+== Arguments
+
+#table(
+  columns: 2,
+  table.header([Argument], [Description]),
+  [`x`], [A basic argument for comparison\.],
+  [`method`], [
+    The method to use, described as a nested list:
+
+    - `"a"`: Use method A, the default\.
+    - `"b"`: Use method B instead\.
+  ],
+  [`describe_arg`], [
+    The method to use, described with a definition list:
+
+    #terms(
+      terms.item(["a"], [Use method A\.]),
+      terms.item(["b"], [Use method B\.]),
+    )
+  ],
+  [`table_arg`], [
+    The argument\. See the table:
+
+    #table(
+      columns: 2,
+      align: (left, left,),
+      [Col1], [Col2],
+      [a], [1],
+      [b], [2],
+    )
+  ],
+  [`pre_only`], [
+    ```
+    result <- foo(x)
+    print(result)
+    ```
+  ],
+  [`pre_with_intro`], [
+    Example usage:
+
+    ```
+    result <- foo(x)
+    print(result)
+    ```
+  ],
+  [`backtick_code`], [Use #raw("`a`") or #raw("``nested``") for non-syntactic names\.],
+  [`fence_collision`], [
+    Code containing a fence-like line:
+
+    #raw(block: true, "```r\nx <- 1\n```")
+  ],
+  [`cr_break`], [
+    First line\. \
+     \- hyphen\. \
+     \* asterisk\. \
+     \+ plus\. \
+     1\. ordered period\.
+  ],
+  [#raw("`a`")], [A non-syntactic argument name with single backticks\.],
+  [#raw("``b``")], [A label with a double-backtick run\.],
+  [`multi_paragraph`], [
+    First paragraph\.
+
+    Second paragraph of the description\.
+  ],
+  [`itemize_multi_paragraph`], [
+    Options:
+
+    - First paragraph\.
+
+      Second paragraph of this item\.
+    - Another item\.
+  ],
+)
+
+== Value
+
+Nothing of interest\.
+
+== Examples
+
+```r
+arguments_rich(1, "a", "a", NULL, NULL, NULL, NULL, NULL, NULL, "x", "y")
+```

--- a/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__init_schema_json.snap
@@ -161,10 +161,14 @@ expression: schema
           ]
         },
         "format": {
-          "description": "Output format: \"qmd\" (Quarto Markdown), \"md\" (standard Markdown), or \"rmd\" (R Markdown)",
-          "type": [
-            "string",
-            "null"
+          "description": "Output format: \"qmd\" (Quarto Markdown), \"md\" (standard Markdown), \"rmd\" (R Markdown), or \"typ\" (Typst)",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OutputFormat"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "frontmatter": {
@@ -196,6 +200,31 @@ expression: schema
           ]
         }
       }
+    },
+    "OutputFormat": {
+      "description": "Output format for markdown conversion",
+      "oneOf": [
+        {
+          "description": "Quarto Markdown (.qmd) - uses {r} code blocks for examples",
+          "type": "string",
+          "const": "qmd"
+        },
+        {
+          "description": "Standard Markdown (.md) - uses plain r code blocks",
+          "type": "string",
+          "const": "md"
+        },
+        {
+          "description": "R Markdown (.Rmd) - uses {r} code blocks for examples",
+          "type": "string",
+          "const": "rmd"
+        },
+        {
+          "description": "Typst (.typ) - plain ```r raw blocks, MiTeX math, executable with calepin",
+          "type": "string",
+          "const": "typ"
+        }
+      ]
     }
   }
 }

--- a/crates/rd2qmd-cli/tests/snapshots/integration__simple_typ.snap
+++ b/crates/rd2qmd-cli/tests/snapshots/integration__simple_typ.snap
@@ -1,0 +1,42 @@
+---
+source: crates/rd2qmd-cli/tests/integration.rs
+expression: output
+---
+#set document(title: "A Simple Function")
+#metadata((
+  pagetitle: "A Simple Function — simple",
+  aliases: ("simple",),
+))<rd2qmd>
+
+= A Simple Function
+
+== Description
+
+This is a simple function for testing\.
+
+== Usage
+
+```r
+#| eval: false
+simple(x, y = 1)
+```
+
+== Arguments
+
+#table(
+  columns: 2,
+  table.header([Argument], [Description]),
+  [`x`], [The first argument\.],
+  [`y`], [The second argument, defaults to 1\.],
+)
+
+== Value
+
+Returns the sum of `x` and `y`\.
+
+== Examples
+
+```r
+simple(1, 2)
+simple(10)
+```

--- a/crates/rd2qmd-core/src/convert_ast/assembly.rs
+++ b/crates/rd2qmd-core/src/convert_ast/assembly.rs
@@ -64,11 +64,9 @@ fn convert_fixed_section(
     let mut nodes = vec![Node::heading(2, vec![Node::text(section.kind.heading())])];
 
     match &section.body {
-        FixedSectionBody::Arguments(arguments) => nodes.extend(convert_arguments(
-            arguments,
-            options.arguments_format.clone(),
-            context,
-        )),
+        FixedSectionBody::Arguments(arguments) => {
+            nodes.extend(convert_arguments(arguments, context))
+        }
         FixedSectionBody::Nodes(body) => match section.kind {
             FixedSectionKind::Usage => {
                 nodes.push(Node::code(Some("r".to_owned()), convert_usage(body).trim()));
@@ -78,7 +76,6 @@ fn convert_fixed_section(
                 &ExampleOptions {
                     exec_dontrun: options.exec_dontrun,
                     exec_donttest: options.exec_donttest,
-                    quarto_code_blocks: options.quarto_code_blocks,
                 },
             )),
             _ => nodes.extend(convert_block_content(body, context)),
@@ -133,6 +130,7 @@ mod tests {
             &WriterOptions {
                 frontmatter: None,
                 quarto_code_blocks: options.quarto_code_blocks,
+                arguments_format: Default::default(),
             },
         )
     }

--- a/crates/rd2qmd-core/src/convert_ast/blocks/mod.rs
+++ b/crates/rd2qmd-core/src/convert_ast/blocks/mod.rs
@@ -1,25 +1,18 @@
 //! General block-content assembly for the rd_ast conversion migration.
 
 use rd_ast::{RdArgument, RdNode};
-use rd2qmd_mdast::{Align, Html, Node};
-use tabled::settings::Style;
-use tabled::settings::style::HorizontalLine;
+use rd2qmd_mdast::{ArgumentItem, Node};
 
 use super::{
     inline::{self, InlineConversionContext},
     leaf_text::flatten_verbatim_leaves,
     traversal::{BlockContentItem, scan_block_content},
 };
-use table_cell::flatten_for_table_cell;
 use tag_conversion::{convert_block, convert_paragraph};
 
-mod markdown_text;
-mod table_cell;
 mod tag_conversion;
 #[cfg(test)]
 mod tests;
-
-use markdown_text::{convert_to_markdown_text, render_block_content, render_list_table_cell};
 
 /// Borrowed configuration used while converting general block content.
 #[derive(Clone, Copy)]
@@ -86,164 +79,30 @@ fn convert_custom_section_body(
     nodes
 }
 
-/// Convert an already-structured Arguments section in the requested output format.
+/// Convert an already-structured Arguments section into a semantic
+/// [`Node::Arguments`].
+///
+/// The physical shape (pipe/grid/list table, loose list, a Typst `#table`)
+/// is a presentation choice and belongs to the writer, so nothing here is
+/// pre-rendered: each entry keeps its name as plain text and its description
+/// as block-level nodes.
 pub(crate) fn convert_arguments(
     arguments: &[RdArgument<'_>],
-    format: crate::ArgumentsFormat,
-    context: &BlockConversionContext<'_>,
-) -> Vec<Node> {
-    match format {
-        crate::ArgumentsFormat::PipeTable => convert_arguments_pipe(arguments, context),
-        crate::ArgumentsFormat::GridTable => convert_arguments_grid(arguments, context),
-        crate::ArgumentsFormat::ListTable => convert_arguments_list_table(arguments, context),
-        crate::ArgumentsFormat::List => convert_arguments_list(arguments, context),
-    }
-}
-
-/// Convert arguments to pipe table format.
-/// Pipe tables cannot contain block elements (lists, multiple paragraphs).
-/// Workaround: use `<br>` for line breaks and flatten lists with bullet markers.
-fn convert_arguments_pipe(
-    arguments: &[RdArgument<'_>],
     context: &BlockConversionContext<'_>,
 ) -> Vec<Node> {
     if arguments.is_empty() {
         return Vec::new();
     }
 
-    let header_row = Node::table_row(vec![
-        Node::table_cell(vec![Node::text("Argument")]),
-        Node::table_cell(vec![Node::text("Description")]),
-    ]);
-    let mut rows = vec![header_row];
-
-    for argument in arguments {
-        let term_text =
-            replace_line_endings_with_space(&argument_name(argument, context)).replace('|', "\\|");
-        rows.push(Node::table_row(vec![
-            Node::table_cell(vec![Node::inline_code(term_text.trim())]),
-            Node::table_cell(flatten_for_table_cell(argument.description, context)),
-        ]));
-    }
-
-    vec![Node::table(
-        vec![Some(Align::Left), Some(Align::Left)],
-        rows,
-    )]
-}
-
-/// Convert arguments to Pandoc grid table format.
-/// Grid tables support block elements (lists, paragraphs) within cells.
-fn convert_arguments_grid(
-    arguments: &[RdArgument<'_>],
-    context: &BlockConversionContext<'_>,
-) -> Vec<Node> {
-    use tabled::builder::Builder;
-
-    if arguments.is_empty() {
-        return Vec::new();
-    }
-
-    let mut builder = Builder::default();
-    builder.push_record(["Argument", "Description"]);
-
-    for argument in arguments {
-        let term_text = argument_name(argument, context);
-        let arg_text = rd2qmd_mdast::format_inline_code(term_text.trim(), false);
-        let desc_text = convert_to_markdown_text(argument.description, context);
-        builder.push_record([arg_text, desc_text]);
-    }
-
-    let mut table = builder.build();
-    let grid_style = Style::ascii().horizontals([(
-        1,
-        HorizontalLine::new('=')
-            .left('+')
-            .right('+')
-            .intersection('+'),
-    )]);
-    let grid_table = table.with(grid_style).to_string();
-
-    vec![Node::Html(Html { value: grid_table })]
-}
-
-/// Convert arguments to Quarto list-table format.
-/// Requires Quarto 1.9+ and is compatible with q2.
-fn convert_arguments_list_table(
-    arguments: &[RdArgument<'_>],
-    context: &BlockConversionContext<'_>,
-) -> Vec<Node> {
-    if arguments.is_empty() {
-        return Vec::new();
-    }
-
-    let rows: Vec<_> = arguments
+    let items = arguments
         .iter()
-        .map(|argument| {
-            let term_text = argument_name(argument, context);
-            let arg_text = rd2qmd_mdast::format_inline_code(term_text.trim(), false);
-            let desc_nodes = convert_block_content(argument.description, context);
-            let desc_text = render_list_table_cell(&desc_nodes);
-            (arg_text, desc_text)
+        .map(|argument| ArgumentItem {
+            name: argument_name(argument, context),
+            description: convert_block_content(argument.description, context),
         })
         .collect();
 
-    let mut output = String::new();
-    output.push_str("::: {.list-table header-rows=1}\n\n");
-    output.push_str("- - Argument\n  - Description\n");
-
-    for (arg, desc) in &rows {
-        output.push('\n');
-        output.push_str("- - ");
-        output.push_str(arg);
-        output.push('\n');
-        output.push_str("  - ");
-        output.push_str(desc);
-        output.push('\n');
-    }
-
-    output.push_str("\n:::\n");
-    vec![Node::Html(Html { value: output })]
-}
-
-/// Convert arguments to Markdown loose-list format.
-fn convert_arguments_list(
-    arguments: &[RdArgument<'_>],
-    context: &BlockConversionContext<'_>,
-) -> Vec<Node> {
-    if arguments.is_empty() {
-        return Vec::new();
-    }
-
-    let items: Vec<_> = arguments
-        .iter()
-        .map(|argument| {
-            let term_text = argument_name(argument, context);
-            let arg_code = rd2qmd_mdast::format_inline_code(term_text.trim(), false);
-            let desc_nodes = convert_block_content(argument.description, context);
-            let desc_text = render_block_content(&desc_nodes, 2);
-            (arg_code, desc_text)
-        })
-        .collect();
-
-    let mut output = String::new();
-    for (i, (arg, desc)) in items.iter().enumerate() {
-        if i > 0 {
-            output.push('\n');
-        }
-        output.push_str("- **");
-        output.push_str(arg);
-        output.push_str("**\n");
-
-        if !desc.is_empty() {
-            output.push('\n');
-            output.push_str("  ");
-            output.push_str(desc);
-            output.push('\n');
-        }
-    }
-
-    vec![Node::Html(Html { value: output })]
+    vec![Node::arguments(items)]
 }
 
 fn argument_name(argument: &RdArgument<'_>, context: &BlockConversionContext<'_>) -> String {

--- a/crates/rd2qmd-core/src/convert_ast/blocks/tag_conversion.rs
+++ b/crates/rd2qmd-core/src/convert_ast/blocks/tag_conversion.rs
@@ -7,7 +7,6 @@ use rd2qmd_mdast::{Align, Node};
 use crate::convert_ast::inline::{self, InlineConversionContext};
 use crate::convert_ast::traversal::ParagraphItem;
 
-use super::table_cell::sanitize_table_cell_inline_nodes;
 use super::{BlockConversionContext, convert_block_content, recover_verbatim};
 
 pub(super) fn convert_paragraph(
@@ -129,16 +128,16 @@ fn convert_tabular(
         .rows()
         .iter()
         .map(|row| {
-            let cells =
-                row.cells()
-                    .iter()
-                    .map(|cell| {
-                        let children = sanitize_table_cell_inline_nodes(
-                            &inline::convert_inline_nodes(cell.nodes(), &context.inline),
-                        );
-                        Node::table_cell(children)
-                    })
-                    .collect();
+            let cells = row
+                .cells()
+                .iter()
+                .map(|cell| {
+                    // Cells hold plain inline content; escaping is the
+                    // writer's job, since only it knows whether the table
+                    // becomes pipe-table syntax or something else.
+                    Node::table_cell(inline::convert_inline_nodes(cell.nodes(), &context.inline))
+                })
+                .collect();
             Node::table_row(cells)
         })
         .collect();

--- a/crates/rd2qmd-core/src/convert_ast/blocks/tests.rs
+++ b/crates/rd2qmd-core/src/convert_ast/blocks/tests.rs
@@ -3,14 +3,89 @@ use std::collections::HashMap;
 use rd_ast::{RdDocument, RdNode, RdTag};
 use rd2qmd_mdast::{Node, Root, WriterOptions, mdast_to_qmd};
 
-use super::markdown_text::{convert_to_markdown_text, inline_nodes_to_markdown};
-use super::table_cell::sanitize_table_cell_inline_node;
 use super::{
     BlockConversionContext, convert_arguments, convert_block_content, convert_custom_section,
 };
 use crate::ArgumentsFormat;
 use crate::convert_ast::document::build_custom_sections;
 use crate::convert_ast::inline::{InlineConversionContext, LinkResolutionContext};
+
+fn writer_options(arguments_format: ArgumentsFormat) -> WriterOptions {
+    WriterOptions {
+        frontmatter: None,
+        quarto_code_blocks: true,
+        arguments_format,
+    }
+}
+
+/// Render block nodes through the Markdown writer.
+fn render(nodes: Vec<Node>, arguments_format: ArgumentsFormat) -> String {
+    mdast_to_qmd(&Root::new(nodes), &writer_options(arguments_format))
+}
+
+/// Render inline nodes through the Markdown writer, as one paragraph.
+fn inline_nodes_to_markdown(nodes: &[Node]) -> String {
+    render(
+        vec![Node::paragraph(nodes.to_vec())],
+        ArgumentsFormat::default(),
+    )
+    .trim_end()
+    .to_owned()
+}
+
+/// Convert a document's Arguments section and render it in `format`.
+fn render_arguments(
+    document: &RdDocument,
+    format: ArgumentsFormat,
+    context: &BlockConversionContext<'_>,
+) -> String {
+    let arguments: Vec<_> = document.arguments().collect();
+    render(convert_arguments(&arguments, context), format)
+}
+
+/// The nth `|`-prefixed line of rendered Markdown.
+fn pipe_line(markdown: &str, index: usize) -> &str {
+    markdown
+        .lines()
+        .filter(|line| line.starts_with('|'))
+        .nth(index)
+        .unwrap_or_else(|| panic!("expected pipe-table line {index} in:\n{markdown}"))
+}
+
+/// The cells of the nth body row of a rendered pipe table (0 = first
+/// argument), splitting only on unescaped `|`.
+fn pipe_row(markdown: &str, index: usize) -> Vec<String> {
+    // Skip the header row and the alignment separator.
+    pipe_cells(pipe_line(markdown, index + 2))
+}
+
+/// Split one rendered pipe-table row into cells on unescaped `|`.
+fn pipe_cells(row: &str) -> Vec<String> {
+    let mut cells = vec![String::new()];
+    let mut escaped = false;
+    for character in row.trim_matches('|').chars() {
+        match character {
+            '\\' if !escaped => {
+                escaped = true;
+                cells.last_mut().expect("cell").push(character);
+            }
+            '|' if !escaped => cells.push(String::new()),
+            _ => {
+                escaped = false;
+                cells.last_mut().expect("cell").push(character);
+            }
+        }
+    }
+    cells.iter().map(|cell| cell.trim().to_owned()).collect()
+}
+
+/// The description (second) cell of the nth body row of a pipe table.
+fn description_cell(markdown: &str, index: usize) -> String {
+    pipe_row(markdown, index)
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| panic!("expected a description cell in:\n{markdown}"))
+}
 
 fn context(prefer_ascii_math: bool) -> BlockConversionContext<'static> {
     BlockConversionContext {
@@ -82,13 +157,6 @@ fn argument_document_with_description(description: Vec<RdNode>) -> RdDocument {
         RdTag::Arguments,
         vec![described_item(vec![text("value")], description)],
     )])
-}
-
-fn html_value(nodes: &[Node]) -> &str {
-    let [Node::Html(html)] = nodes else {
-        panic!("expected one raw output node")
-    };
-    &html.value
 }
 
 fn equation(latex: &str, ascii: Option<&str>) -> RdNode {
@@ -311,19 +379,12 @@ fn converts_tabular_alignment_rows_and_sanitized_cells() {
         ]
     );
     assert_eq!(table.children.len(), 2);
-    let Node::TableRow(first_row) = &table.children[0] else {
-        panic!("expected first table row")
-    };
-    let cell_text: Vec<_> = first_row
-        .children
-        .iter()
-        .map(|cell| match cell {
-            Node::TableCell(cell) => inline_nodes_to_markdown(&cell.children),
-            _ => panic!("expected table cell"),
-        })
-        .collect();
+
+    // Cells hold unescaped content; the writer escapes when it commits to
+    // pipe-table syntax.
+    let markdown = render(converted.clone(), ArgumentsFormat::default());
     assert_eq!(
-        cell_text,
+        pipe_cells(pipe_line(&markdown, 0)),
         ["left \\| value", "**center**", "`right\\|code`"]
     );
 }
@@ -336,16 +397,8 @@ fn converts_tabular_block_math_to_pipe_escaped_inline_math() {
     );
 
     let converted = convert_block_content(&[table], &context(false));
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let [Node::TableRow(row)] = table.children.as_slice() else {
-        panic!("expected one table row")
-    };
-    let [Node::TableCell(cell)] = row.children.as_slice() else {
-        panic!("expected one table cell")
-    };
-    assert_eq!(cell.children, [Node::inline_math("x \\| y")]);
+    let markdown = render(converted, ArgumentsFormat::default());
+    assert_eq!(pipe_cells(pipe_line(&markdown, 0)), ["$x \\| y$"]);
 }
 
 #[test]
@@ -359,20 +412,10 @@ fn converts_tabular_multiline_block_math_to_single_line_inline_math() {
     );
 
     let converted = convert_block_content(&[table], &context(false));
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let [Node::TableRow(row)] = table.children.as_slice() else {
-        panic!("expected one table row")
-    };
-    let [Node::TableCell(cell)] = row.children.as_slice() else {
-        panic!("expected one table cell")
-    };
-    assert_eq!(cell.children, [Node::inline_math("x \\| y")]);
-    let [Node::InlineMath(math)] = cell.children.as_slice() else {
-        panic!("expected inline math")
-    };
-    assert!(!math.value.contains('\n'));
+    let markdown = render(converted, ArgumentsFormat::default());
+    // The line ending is flattened during conversion, the pipe escaped by
+    // the writer, and the row stays on one line either way.
+    assert_eq!(pipe_cells(pipe_line(&markdown, 0)), ["$x \\| y$"]);
 }
 
 #[test]
@@ -393,6 +436,7 @@ fn converts_tabular_multiline_ascii_equation_to_single_line_inline_code() {
         &WriterOptions {
             frontmatter: None,
             quarto_code_blocks: true,
+            arguments_format: Default::default(),
         },
     );
     let row = markdown
@@ -400,15 +444,6 @@ fn converts_tabular_multiline_ascii_equation_to_single_line_inline_code() {
         .find(|line| line.contains("x^2"))
         .expect("expected equation table row");
     assert_eq!(row, "| `x^2 +  y^2` |");
-}
-
-#[test]
-fn pipe_table_sanitizer_replaces_only_line_endings() {
-    let sanitized = sanitize_table_cell_inline_node(&Node::inline_code("a  b\tc\r\nd\re\n f"));
-    assert!(matches!(
-        sanitized,
-        Node::InlineCode(code) if code.value == "a  b\tc d e  f"
-    ));
 }
 
 #[test]
@@ -427,6 +462,7 @@ fn converts_multiline_out_in_tabular_cell_to_one_pipe_table_row() {
         &WriterOptions {
             frontmatter: None,
             quarto_code_blocks: true,
+            arguments_format: Default::default(),
         },
     );
     let rows: Vec<_> = markdown
@@ -434,71 +470,6 @@ fn converts_multiline_out_in_tabular_cell_to_one_pipe_table_row() {
         .filter(|line| line.starts_with('|'))
         .collect();
     assert_eq!(rows, ["| first second |", "|:---|"]);
-}
-
-#[test]
-fn pipe_table_sanitizer_replaces_link_title_line_endings() {
-    let mut url = String::from(r"url");
-    url.push('\n');
-    url.push_str(r"value");
-    let mut title = String::from(r"title");
-    title.push('\r');
-    title.push('\n');
-    title.push_str(r"value");
-    let sanitized = sanitize_table_cell_inline_node(&Node::link_with_title(
-        url,
-        title,
-        vec![Node::text(r"link")],
-    ));
-    let markdown = mdast_to_qmd(
-        &Root::new(vec![Node::paragraph(vec![sanitized])]),
-        &WriterOptions::default(),
-    );
-
-    let mut expected = String::from(r#"[link](<url value> "title value")"#);
-    expected.push('\n');
-    assert_eq!(markdown, expected);
-}
-
-#[test]
-fn pipe_table_sanitizer_replaces_image_field_line_endings() {
-    let mut url = String::from(r"url");
-    url.push('\r');
-    url.push_str(r"value");
-    let mut alt = String::from(r"alt");
-    alt.push('\n');
-    alt.push_str(r"value");
-    let mut title = String::from(r"title");
-    title.push('\r');
-    title.push('\n');
-    title.push_str(r"value");
-    let sanitized = sanitize_table_cell_inline_node(&Node::image_with_title(url, alt, title));
-    let markdown = mdast_to_qmd(
-        &Root::new(vec![Node::paragraph(vec![sanitized])]),
-        &WriterOptions::default(),
-    );
-
-    let mut expected = String::from(r#"![alt value](<url value> "title value")"#);
-    expected.push('\n');
-    assert_eq!(markdown, expected);
-}
-
-#[test]
-fn legacy_table_cell_serializer_formats_link_and_image_destinations() {
-    let markdown = inline_nodes_to_markdown(&[
-        Node::link_with_title(
-            r"link url",
-            r#"link "title" \ docs"#,
-            vec![Node::text(r"link")],
-        ),
-        Node::text(r" "),
-        Node::image_with_title(r"image url", r"alt", r#"image "title" \ docs"#),
-    ]);
-
-    assert_eq!(
-        markdown,
-        r#"[link](<link url> "link \"title\" \\ docs") ![alt](<image url> "image \"title\" \\ docs")"#
-    );
 }
 
 #[test]
@@ -567,34 +538,22 @@ fn custom_section_tree_preserves_content_around_nested_subsections() {
 #[test]
 fn converts_arguments_to_pipe_table_and_flattens_lists_with_breaks() {
     let document = argument_document();
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
+    let converted = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    assert_eq!(table.align, [Some(rd2qmd_mdast::Align::Left); 2]);
-    assert_eq!(table.children.len(), 3);
-
-    let Node::TableRow(first_argument) = &table.children[1] else {
-        panic!("expected first argument row")
-    };
-    let Node::TableCell(first_description) = &first_argument.children[1] else {
-        panic!("expected first description cell")
-    };
+    let rows: Vec<_> = converted
+        .lines()
+        .filter(|line| line.starts_with('|'))
+        .collect();
+    assert_eq!(rows.len(), 4, "header, separator and two argument rows");
+    assert_eq!(rows[1], "|:---|:---|");
+    assert_eq!(pipe_row(&converted, 0)[0], "`alpha`");
     assert_eq!(
-        inline_nodes_to_markdown(&first_description.children),
+        description_cell(&converted, 0),
         "First paragraph <br>Second paragraph"
     );
-
-    let Node::TableRow(second_argument) = &table.children[2] else {
-        panic!("expected second argument row")
-    };
-    let Node::TableCell(second_description) = &second_argument.children[1] else {
-        panic!("expected second description cell")
-    };
+    assert_eq!(pipe_row(&converted, 1)[0], "`choice`");
     assert_eq!(
-        inline_nodes_to_markdown(&second_description.children),
+        description_cell(&converted, 1),
         "Choices: <br>- one <br>- two"
     );
 }
@@ -606,85 +565,34 @@ fn pipe_table_replaces_inline_breaks_with_html_breaks() {
         tagged(RdTag::Cr, vec![]),
         text("after"),
     ]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
+    let converted = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let Node::TableRow(row) = &table.children[1] else {
-        panic!("expected argument row")
-    };
-    let Node::TableCell(description) = &row.children[1] else {
-        panic!("expected description cell")
-    };
-
+    // A `\cr` becomes an HTML break, not a Markdown hard break, which would
+    // split the row across two lines.
+    assert_eq!(description_cell(&converted, 0), "before<br>after");
     assert_eq!(
-        inline_nodes_to_markdown(&description.children),
-        "before<br>after"
-    );
-    assert!(
-        description
-            .children
-            .iter()
-            .any(|node| matches!(node, Node::Html(html) if html.value == "<br>"))
-    );
-    assert!(
-        !description
-            .children
-            .iter()
-            .any(|node| matches!(node, Node::Break))
+        converted
+            .lines()
+            .filter(|line| line.starts_with('|'))
+            .count(),
+        3
     );
 }
 
 #[test]
 fn pipe_table_escapes_literal_pipes_in_text() {
     let document = argument_document_with_description(vec![text("left | right")]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
+    let converted = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let Node::TableRow(row) = &table.children[1] else {
-        panic!("expected argument row")
-    };
-    let Node::TableCell(description) = &row.children[1] else {
-        panic!("expected description cell")
-    };
-
-    assert_eq!(
-        inline_nodes_to_markdown(&description.children),
-        "left \\| right"
-    );
-    assert!(description.children.iter().all(|node| {
-        !matches!(node, Node::Text(text) if text.value.contains('|') && !text.value.contains("\\|"))
-    }));
+    assert_eq!(description_cell(&converted, 0), "left \\| right");
 }
 
 #[test]
 fn pipe_table_escapes_literal_pipes_in_inline_code() {
     let document = argument_document_with_description(vec![tagged(RdTag::Code, vec![text("a|b")])]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
+    let converted = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let Node::TableRow(row) = &table.children[1] else {
-        panic!("expected argument row")
-    };
-    let Node::TableCell(description) = &row.children[1] else {
-        panic!("expected description cell")
-    };
-
-    assert_eq!(inline_nodes_to_markdown(&description.children), "`a\\|b`");
-    assert!(
-        description
-            .children
-            .iter()
-            .any(|node| matches!(node, Node::InlineCode(code) if code.value == "a\\|b"))
-    );
+    assert_eq!(description_cell(&converted, 0), "`a\\|b`");
 }
 
 #[test]
@@ -693,23 +601,9 @@ fn pipe_table_escapes_literal_pipes_in_argument_names() {
         RdTag::Arguments,
         vec![described_item(vec![text("a|b")], vec![text("description")])],
     )]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
+    let converted = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let Node::TableRow(row) = &table.children[1] else {
-        panic!("expected argument row")
-    };
-    let Node::TableCell(argument) = &row.children[0] else {
-        panic!("expected argument cell")
-    };
-
-    assert!(
-        matches!(argument.children.as_slice(), [Node::InlineCode(code)] if code.value == "a\\|b")
-    );
-    assert_eq!(inline_nodes_to_markdown(&argument.children), "`a\\|b`");
+    assert_eq!(pipe_row(&converted, 0)[0], "`a\\|b`");
 }
 
 #[test]
@@ -728,49 +622,10 @@ fn pipe_table_flattens_and_escapes_nested_conditional_paragraphs() {
         ],
     );
     let document = argument_document_with_description(vec![multi_node_conditional]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let Node::TableRow(row) = &table.children[1] else {
-        panic!("expected argument row")
-    };
-    let Node::TableCell(description) = &row.children[1] else {
-        panic!("expected description cell")
-    };
-
-    // Structural invariant: no Paragraph (block node) may survive as a
-    // TableCell child, at any nesting depth.
-    fn assert_no_paragraphs(nodes: &[Node]) {
-        for node in nodes {
-            assert!(
-                !matches!(node, Node::Paragraph(_)),
-                "unexpected Paragraph in table-cell content: {node:?}"
-            );
-            let children: &[Node] = match node {
-                Node::Emphasis(e) => &e.children,
-                Node::Strong(s) => &s.children,
-                Node::Link(l) => &l.children,
-                _ => &[],
-            };
-            assert_no_paragraphs(children);
-        }
-    }
-    assert_no_paragraphs(&description.children);
-
-    // Render through the real writer -- not the file-local
-    // inline_nodes_to_markdown helper, whose own Paragraph-unwrapping
-    // fallback would mask exactly this class of bug -- and confirm the
-    // row stays a single line with pipes escaped.
-    let markdown = mdast_to_qmd(
-        &Root::new(vec![Node::Table(table.clone())]),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    // A surviving Paragraph would break the row across several lines, so the
+    // single-line row is itself the structural assertion.
     let row_line = markdown
         .lines()
         .find(|line| line.contains("value"))
@@ -783,22 +638,14 @@ fn pipe_table_flattens_and_escapes_nested_conditional_paragraphs() {
         !row_line.contains("c|d") && row_line.contains(r"c\|d"),
         "expected escaped pipe in flattened paragraph inline code, got: {markdown:?}"
     );
-}
-
-#[test]
-fn pipe_table_sanitizer_escapes_literal_pipes_in_image_urls() {
-    let sanitized = sanitize_table_cell_inline_node(&Node::image("path|name.png", "alt"));
-
-    assert!(
-        matches!(sanitized, Node::Image(image) if image.url == "path\\|name.png" && image.alt == "alt")
+    assert_eq!(
+        markdown
+            .lines()
+            .filter(|line| line.starts_with('|'))
+            .count(),
+        3,
+        "expected exactly a header, separator and one argument row: {markdown:?}"
     );
-}
-
-#[test]
-fn pipe_table_sanitizer_replaces_inline_code_line_endings() {
-    let sanitized = sanitize_table_cell_inline_node(&Node::inline_code("first\n second"));
-
-    assert!(matches!(sanitized, Node::InlineCode(code) if code.value == "first  second"));
 }
 
 #[test]
@@ -810,15 +657,7 @@ fn pipe_table_collapses_multiline_argument_names_through_real_writer() {
             vec![text("description")],
         )],
     )]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
     let row = markdown
         .lines()
@@ -849,38 +688,22 @@ fn pipe_table_escapes_literal_pipes_in_resolved_links() {
         prefer_ascii_math: false,
         enclosing_heading_depth: 2,
     };
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context);
-
-    let [Node::Table(table)] = converted.as_slice() else {
-        panic!("expected one table")
-    };
-    let Node::TableRow(row) = &table.children[1] else {
-        panic!("expected argument row")
-    };
-    let Node::TableCell(description) = &row.children[1] else {
-        panic!("expected description cell")
-    };
+    let converted = render(
+        convert_arguments(&arguments, &context),
+        ArgumentsFormat::PipeTable,
+    );
 
     assert_eq!(
-        inline_nodes_to_markdown(&description.children),
+        description_cell(&converted, 0),
         "[`a\\|b`](target\\|variant.qmd#alias)"
     );
-    assert!(description.children.iter().any(|node| {
-        matches!(
-            node,
-            Node::Link(link)
-                if link.url == "target\\|variant.qmd#alias"
-                    && matches!(link.children.as_slice(), [Node::InlineCode(code)] if code.value == "a\\|b")
-        )
-    }));
 }
 
 #[test]
 fn converts_arguments_to_grid_table_with_header_separator() {
     let document = argument_document();
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::GridTable, &context(false));
-    let table = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::GridTable, &context(false));
+    let table = converted.as_str();
 
     assert!(table.contains("Argument"));
     assert!(table.contains("Description"));
@@ -897,9 +720,8 @@ fn converts_arguments_to_grid_table_with_header_separator() {
 #[test]
 fn grid_table_preserves_block_equations() {
     let document = argument_document_with_description(vec![equation("x^2 + y^2", None)]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::GridTable, &context(false));
-    let table = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::GridTable, &context(false));
+    let table = converted.as_str();
 
     assert!(table.contains("$$"));
     assert!(table.contains("x^2 + y^2"));
@@ -915,9 +737,8 @@ fn grid_table_preserves_nested_definition_lists() {
         )],
     );
     let document = argument_document_with_description(vec![describe]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::GridTable, &context(false));
-    let table = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::GridTable, &context(false));
+    let table = converted.as_str();
 
     assert!(table.contains("nested term"));
     assert!(table.contains("nested description"));
@@ -926,9 +747,8 @@ fn grid_table_preserves_nested_definition_lists() {
 #[test]
 fn converts_arguments_to_quarto_list_table() {
     let document = argument_document();
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::ListTable, &context(false));
-    let table = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::ListTable, &context(false));
+    let table = converted.as_str();
 
     assert!(table.starts_with("::: {.list-table header-rows=1}\n\n"));
     assert!(table.contains("- - Argument\n  - Description\n"));
@@ -940,9 +760,8 @@ fn converts_arguments_to_quarto_list_table() {
 #[test]
 fn list_table_preserves_indented_block_equations() {
     let document = argument_document_with_description(vec![equation("x^2 + y^2", None)]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::ListTable, &context(false));
-    let table = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::ListTable, &context(false));
+    let table = converted.as_str();
 
     assert!(table.contains("  - \n\n    $$\n    x^2 + y^2\n    $$\n"));
 }
@@ -950,9 +769,8 @@ fn list_table_preserves_indented_block_equations() {
 #[test]
 fn converts_arguments_to_loose_list_with_two_space_continuations() {
     let document = argument_document();
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::List, &context(false));
-    let list = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::List, &context(false));
+    let list = converted.as_str();
 
     assert!(list.contains("- **`alpha`**\n\n  First paragraph\n\n  Second paragraph\n"));
     assert!(list.contains("- **`choice`**\n\n  Choices:\n\n  - one\n  - two\n"));
@@ -961,16 +779,15 @@ fn converts_arguments_to_loose_list_with_two_space_continuations() {
 #[test]
 fn loose_list_preserves_indented_block_equations() {
     let document = argument_document_with_description(vec![equation("x^2 + y^2", None)]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::List, &context(false));
-    let list = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::List, &context(false));
+    let list = converted.as_str();
 
     assert!(list.contains("- **`value`**\n\n  \n\n  $$\n  x^2 + y^2\n  $$\n"));
 }
 
 #[test]
 fn empty_arguments_return_no_nodes() {
-    assert!(convert_arguments(&[], ArgumentsFormat::PipeTable, &context(false)).is_empty());
+    assert!(convert_arguments(&[], &context(false)).is_empty());
 }
 
 #[test]
@@ -990,15 +807,7 @@ fn pipe_table_preserves_describe_tabular_and_preformatted_content() {
     );
     let preformatted = tagged(RdTag::Preformatted, vec![text("preformatted text")]);
     let document = argument_document_with_description(vec![describe, table, preformatted]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
     let row = markdown
         .lines()
         .find(|line| line.contains("value"))
@@ -1031,15 +840,7 @@ fn pipe_table_preserves_both_paragraphs_of_a_multi_paragraph_list_item() {
         vec![vec![text("first paragraph\n\nsecond paragraph")]],
     );
     let document = argument_document_with_description(vec![list]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
     let row = markdown
         .lines()
         .find(|line| line.contains("value"))
@@ -1058,9 +859,8 @@ fn grid_table_preserves_tabular_content() {
         vec![group(vec![text("l")]), group(vec![text("table cell text")])],
     );
     let document = argument_document_with_description(vec![table]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::GridTable, &context(false));
-    let table_text = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::GridTable, &context(false));
+    let table_text = converted.as_str();
 
     assert!(
         table_text.contains("table cell text"),
@@ -1077,9 +877,8 @@ fn grid_table_preserves_both_paragraphs_of_a_multi_paragraph_list_item() {
         vec![vec![text("first paragraph\n\nsecond paragraph")]],
     );
     let document = argument_document_with_description(vec![list]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::GridTable, &context(false));
-    let table_text = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::GridTable, &context(false));
+    let table_text = converted.as_str();
 
     assert!(
         table_text.contains("first paragraph"),
@@ -1089,40 +888,6 @@ fn grid_table_preserves_both_paragraphs_of_a_multi_paragraph_list_item() {
         table_text.contains("second paragraph"),
         "got: {table_text:?}"
     );
-}
-
-#[test]
-fn grid_table_list_item_second_paragraph_is_indented_under_marker() {
-    // Regression test for Bug 1: a list item's continuation content
-    // (here, a second paragraph) must be indented under the marker
-    // column, or a grid-table cell's block-level Markdown parser stops
-    // treating it as part of the same list item.
-    let list = delimited_list(
-        RdTag::Itemize,
-        vec![vec![text("first paragraph\n\nsecond paragraph")]],
-    );
-    let markdown = convert_to_markdown_text(&[list], &context(false));
-
-    assert_eq!(markdown, "- first paragraph\n\n  second paragraph");
-}
-
-#[test]
-fn grid_table_list_item_cr_break_in_first_paragraph_is_indented_under_marker() {
-    // Regression test for the latent bug Bug 1's fix also closes: a
-    // `\cr`-induced line break *within the first paragraph* of a list
-    // item must also be indented under the marker, not just subsequent
-    // sibling blocks.
-    let list = delimited_list(
-        RdTag::Itemize,
-        vec![vec![
-            text("first line"),
-            tagged(RdTag::Cr, vec![]),
-            text("second line"),
-        ]],
-    );
-    let markdown = convert_to_markdown_text(&[list], &context(false));
-
-    assert_eq!(markdown, "- first line  \n  second line");
 }
 
 #[test]
@@ -1140,15 +905,7 @@ fn pipe_table_nested_tabular_pipe_is_not_double_escaped() {
         RdTag::Arguments,
         vec![described_item(vec![text("table_arg")], vec![table])],
     )]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
     let row = markdown
         .lines()
         .find(|line| line.contains("table_arg"))
@@ -1207,15 +964,7 @@ fn pipe_table_tabular_nested_in_describe_pipe_is_not_double_escaped() {
         RdTag::Arguments,
         vec![described_item(vec![text("describe_arg")], vec![describe])],
     )]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
     let row = markdown
         .lines()
         .find(|line| line.contains("describe_arg"))
@@ -1246,15 +995,7 @@ fn pipe_table_preformatted_pipe_preserves_backslash() {
     // original backslash from the rendered code.
     let preformatted = tagged(RdTag::Preformatted, vec![text(r"a\|b")]);
     let document = argument_document_with_description(vec![preformatted]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
     assert!(
         markdown.contains(r"`a\\|b`"),
@@ -1270,15 +1011,7 @@ fn pipe_table_math_pipe_preserves_backslash() {
     // content, not treated as already-escaped table syntax.
     let deqn = equation(r"a\|b", None);
     let document = argument_document_with_description(vec![deqn]);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::PipeTable, &context(false));
-    let markdown = mdast_to_qmd(
-        &Root::new(converted),
-        &WriterOptions {
-            frontmatter: None,
-            quarto_code_blocks: true,
-        },
-    );
+    let markdown = render_arguments(&document, ArgumentsFormat::PipeTable, &context(false));
 
     assert!(
         markdown.contains(r"a\\|b"),
@@ -1304,9 +1037,8 @@ fn grid_table_escapes_list_marker_lookalikes_after_cr_break() {
         text(" 1. ordered period."),
     ];
     let document = argument_document_with_description(description);
-    let arguments: Vec<_> = document.arguments().collect();
-    let converted = convert_arguments(&arguments, ArgumentsFormat::GridTable, &context(false));
-    let table_text = html_value(&converted);
+    let converted = render_arguments(&document, ArgumentsFormat::GridTable, &context(false));
+    let table_text = converted.as_str();
 
     assert!(table_text.contains(r"\- hyphen."), "got: {table_text:?}");
     assert!(table_text.contains(r"\* asterisk."), "got: {table_text:?}");

--- a/crates/rd2qmd-core/src/convert_ast/code.rs
+++ b/crates/rd2qmd-core/src/convert_ast/code.rs
@@ -9,7 +9,6 @@ use super::leaf_text::flatten_verbatim_leaves;
 pub(crate) struct ExampleOptions {
     pub(crate) exec_dontrun: bool,
     pub(crate) exec_donttest: bool,
-    pub(crate) quarto_code_blocks: bool,
 }
 
 /// Flatten a Usage section while preserving its source whitespace.
@@ -71,9 +70,11 @@ pub(crate) fn convert_examples(nodes: &[RdNode], options: &ExampleOptions) -> Ve
                     flush_code(&mut current_code, &mut result, true);
                     has_executable = false;
 
-                    if options.quarto_code_blocks {
-                        push_code(&mut result, &format!("#| include: false\n{trimmed}"), true);
-                    }
+                    result.push(Node::code_with_meta(
+                        Some("r".to_owned()),
+                        Some("hidden".to_owned()),
+                        trimmed,
+                    ));
                 }
             }
             RdExampleControlKind::DontDiff => {
@@ -358,12 +359,11 @@ mod tests {
     fn example_options(
         exec_dontrun: bool,
         exec_donttest: bool,
-        quarto_code_blocks: bool,
+        _quarto_code_blocks: bool,
     ) -> ExampleOptions {
         ExampleOptions {
             exec_dontrun,
             exec_donttest,
-            quarto_code_blocks,
         }
     }
 
@@ -377,6 +377,10 @@ mod tests {
 
     fn plain(value: &str) -> Node {
         Node::code(Some("r".to_string()), value)
+    }
+
+    fn hidden(value: &str) -> Node {
+        Node::code_with_meta(Some("r".to_string()), Some("hidden".to_string()), value)
     }
 
     fn method(tag: RdTag, generic: &str, qualifier: &str) -> RdNode {
@@ -584,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn genuine_dontshow_is_hidden_in_quarto_and_omitted_otherwise() {
+    fn genuine_dontshow_is_preserved_as_hidden_setup_code() {
         let nodes = vec![control(
             RdTag::DontShow,
             vec![RdNode::RCode("setup()\n".to_owned())],
@@ -592,9 +596,12 @@ mod tests {
 
         assert_eq!(
             convert_examples(&nodes, &example_options(false, false, true)),
-            vec![executable("#| include: false\nsetup()")]
+            vec![hidden("setup()")]
         );
-        assert!(convert_examples(&nodes, &example_options(false, false, false)).is_empty());
+        assert_eq!(
+            convert_examples(&nodes, &example_options(false, false, false)),
+            vec![hidden("setup()")]
+        );
     }
 
     #[test]
@@ -651,9 +658,12 @@ mod tests {
 
         assert_eq!(
             convert_examples(&complete, &example_options(false, false, true)),
-            vec![executable("#| include: false\nstopifnot(TRUE)")]
+            vec![hidden("stopifnot(TRUE)")]
         );
-        assert!(convert_examples(&complete, &example_options(false, false, false)).is_empty());
+        assert_eq!(
+            convert_examples(&complete, &example_options(false, false, false)),
+            vec![hidden("stopifnot(TRUE)")]
+        );
         assert_eq!(
             convert_examples(&wrappers, &example_options(false, false, true)),
             vec![executable("inside()")]

--- a/crates/rd2qmd-core/src/convert_ast/inline.rs
+++ b/crates/rd2qmd-core/src/convert_ast/inline.rs
@@ -222,6 +222,12 @@ pub(crate) fn extract_plain_text(nodes: &[Node]) -> String {
             Node::DefinitionList(node) => append_children_text(&node.children, text),
             Node::DefinitionTerm(node) => append_children_text(&node.children, text),
             Node::DefinitionDescription(node) => append_children_text(&node.children, text),
+            Node::Arguments(node) => {
+                for item in &node.items {
+                    text.push_str(&item.name);
+                    append_children_text(&item.description, text);
+                }
+            }
             Node::Text(node) => text.push_str(&node.value),
             Node::Emphasis(node) => append_children_text(&node.children, text),
             Node::Strong(node) => append_children_text(&node.children, text),
@@ -558,6 +564,7 @@ mod tests {
             &WriterOptions {
                 frontmatter: None,
                 quarto_code_blocks: false,
+                arguments_format: Default::default(),
             },
         )
     }

--- a/crates/rd2qmd-core/src/convert_ast/roxygen.rs
+++ b/crates/rd2qmd-core/src/convert_ast/roxygen.rs
@@ -217,6 +217,7 @@ mod tests {
                 &WriterOptions {
                     frontmatter: None,
                     quarto_code_blocks: false,
+                    arguments_format: Default::default(),
                 }
             ),
             "```r\nx <- 1 + 2\n```\n"

--- a/crates/rd2qmd-core/src/lib.rs
+++ b/crates/rd2qmd-core/src/lib.rs
@@ -8,7 +8,20 @@ mod source_parse;
 pub use ast_io::{AST_FORMAT_VERSION, AstIoError, RdAstEnvelope};
 pub use options::{ArgumentsFormat, RdToMdastOptions};
 pub use rd_ast::{RdDocument, RdNode};
-pub use rd2qmd_mdast::{Frontmatter, RdMetadata, WriterOptions, mdast_to_qmd};
+pub use rd2qmd_mdast::{
+    Frontmatter, RdMetadata, TypstWriterOptions, WriterOptions, mdast_to_qmd, mdast_to_typst,
+};
+
+/// Markup language a document is rendered into.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OutputTarget {
+    /// Quarto / R / standard Markdown.
+    #[default]
+    Markdown,
+    /// Typst markup (`.typ`), compilable to PDF or, with Typst 0.15's
+    /// experimental HTML export, to HTML.
+    Typst,
+}
 
 /// Frontmatter output options.
 #[derive(Debug, Clone, Default)]
@@ -51,6 +64,8 @@ pub struct RdConvertOptions {
     pub frontmatter: FrontmatterOptions,
     pub code: CodeExecutionOptions,
     pub links: LinkOptions,
+    /// Markup language to render into.
+    pub target: OutputTarget,
     pub arguments_format: ArgumentsFormat,
     pub include_html_output: bool,
     pub prefer_ascii_math: bool,
@@ -167,7 +182,6 @@ pub fn convert_rd_document(doc: &RdDocument, options: &RdConvertOptions) -> Stri
         exec_dontrun: options.code.exec_dontrun,
         exec_donttest: options.code.exec_donttest,
         quarto_code_blocks: options.code.quarto_code_blocks,
-        arguments_format: options.arguments_format.clone(),
         include_html_output: options.include_html_output,
         prefer_ascii_math: options.prefer_ascii_math,
     };
@@ -189,16 +203,30 @@ pub fn convert_rd_document(doc: &RdDocument, options: &RdConvertOptions) -> Stri
         },
         None => extract_rd_metadata(doc),
     };
-    let writer_options = WriterOptions {
-        frontmatter: options.frontmatter.enabled.then_some(Frontmatter {
-            title,
-            pagetitle,
-            format: None,
-            metadata: Some(metadata),
-        }),
-        quarto_code_blocks: options.code.quarto_code_blocks,
-    };
-    mdast_to_qmd(&mdast, &writer_options)
+    let frontmatter = options.frontmatter.enabled.then_some(Frontmatter {
+        title,
+        pagetitle,
+        format: None,
+        metadata: Some(metadata),
+    });
+
+    match options.target {
+        OutputTarget::Markdown => mdast_to_qmd(
+            &mdast,
+            &WriterOptions {
+                frontmatter,
+                quarto_code_blocks: options.code.quarto_code_blocks,
+                arguments_format: options.arguments_format,
+            },
+        ),
+        OutputTarget::Typst => mdast_to_typst(
+            &mdast,
+            &TypstWriterOptions {
+                frontmatter,
+                arguments_format: options.arguments_format,
+            },
+        ),
+    }
 }
 
 /// Convert a document to mdast with default options.

--- a/crates/rd2qmd-core/src/options.rs
+++ b/crates/rd2qmd-core/src/options.rs
@@ -1,14 +1,6 @@
 use std::collections::HashMap;
 
-/// Format for the Arguments section output.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum ArgumentsFormat {
-    PipeTable,
-    GridTable,
-    #[default]
-    ListTable,
-    List,
-}
+pub use rd2qmd_mdast::ArgumentsFormat;
 
 /// Options for converting an Rd document to mdast.
 #[derive(Debug, Clone)]
@@ -22,7 +14,6 @@ pub struct RdToMdastOptions {
     pub exec_dontrun: bool,
     pub exec_donttest: bool,
     pub quarto_code_blocks: bool,
-    pub arguments_format: ArgumentsFormat,
     pub include_html_output: bool,
     pub prefer_ascii_math: bool,
 }
@@ -39,7 +30,6 @@ impl Default for RdToMdastOptions {
             exec_dontrun: false,
             exec_donttest: true,
             quarto_code_blocks: true,
-            arguments_format: ArgumentsFormat::default(),
             include_html_output: false,
             prefer_ascii_math: false,
         }

--- a/crates/rd2qmd-mdast/Cargo.toml
+++ b/crates/rd2qmd-mdast/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["text-processing"]
 
 [dependencies]
 serde = { workspace = true }
+tabled.workspace = true
+html-escape.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/rd2qmd-mdast/src/lib.rs
+++ b/crates/rd2qmd-mdast/src/lib.rs
@@ -19,16 +19,18 @@
 //! ```
 
 pub mod mdast;
+pub mod typst;
 pub mod writer;
 
 pub use mdast::{
-    Align, Blockquote, Code, DefinitionDescription, DefinitionList, DefinitionTerm, Emphasis,
-    Heading, Html, Image, InlineCode, InlineMath, Link, List, ListItem, Math, Node, Paragraph,
-    Root, Strong, Table, TableCell, TableRow, Text,
+    Align, ArgumentItem, Arguments, Blockquote, Code, DefinitionDescription, DefinitionList,
+    DefinitionTerm, Emphasis, Heading, Html, Image, InlineCode, InlineMath, Link, List, ListItem,
+    Math, Node, Paragraph, Root, Strong, Table, TableCell, TableRow, Text,
 };
+pub use typst::{MITEX_VERSION, TypstWriterOptions, mdast_to_typst};
 pub use writer::{
-    Frontmatter, RdMetadata, WriterOptions, escape_link_title, format_link_destination,
-    mdast_to_qmd,
+    ArgumentsFormat, Frontmatter, RdMetadata, WriterOptions, escape_link_title,
+    format_link_destination, mdast_to_qmd,
 };
 
 /// Format an inline code value as a Markdown code span, with safe backtick fencing.

--- a/crates/rd2qmd-mdast/src/mdast.rs
+++ b/crates/rd2qmd-mdast/src/mdast.rs
@@ -29,6 +29,12 @@ pub enum Node {
 
     // Container for definition lists (not standard mdast, but useful)
     DefinitionList(DefinitionList),
+    /// An Rd `\arguments{}` section (not standard mdast).
+    ///
+    /// Held semantically -- a list of (name, block description) entries --
+    /// rather than pre-rendered, so each writer picks its own physical
+    /// rendering (pipe/grid/list table, loose list, Typst `#table`).
+    Arguments(Arguments),
     DefinitionTerm(DefinitionTerm),
     DefinitionDescription(DefinitionDescription),
 
@@ -118,6 +124,21 @@ pub enum Align {
     Left,
     Center,
     Right,
+}
+
+/// An Rd `\arguments{}` section (extension)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Arguments {
+    pub items: Vec<ArgumentItem>,
+}
+
+/// One entry of an [`Arguments`] section
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArgumentItem {
+    /// Argument name(s) as plain text, e.g. `x` or `..., .by`.
+    pub name: String,
+    /// Description as block-level mdast nodes.
+    pub description: Vec<Node>,
 }
 
 /// Definition list (extension)
@@ -319,6 +340,10 @@ impl Node {
 
     pub fn table_cell(children: Vec<Node>) -> Self {
         Node::TableCell(TableCell { children })
+    }
+
+    pub fn arguments(items: Vec<ArgumentItem>) -> Self {
+        Node::Arguments(Arguments { items })
     }
 
     pub fn definition_list(children: Vec<Node>) -> Self {

--- a/crates/rd2qmd-mdast/src/typst/block.rs
+++ b/crates/rd2qmd-mdast/src/typst/block.rs
@@ -1,0 +1,271 @@
+//! Block-level Typst writers.
+
+use super::inline::raw_block;
+use super::{TypstWriter, indent_continuation};
+use crate::mdast::{Align, ArgumentItem, Arguments, Node};
+use crate::writer::ArgumentsFormat;
+
+impl TypstWriter<'_> {
+    pub(super) fn write_heading(&mut self, h: &crate::mdast::Heading) {
+        self.ensure_newline();
+        for _ in 0..h.depth {
+            self.output.push('=');
+        }
+        self.output.push(' ');
+        for child in &h.children {
+            self.write_node(child);
+        }
+        self.output.push('\n');
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_paragraph(&mut self, p: &crate::mdast::Paragraph) {
+        self.ensure_newline();
+        for child in &p.children {
+            self.write_node(child);
+        }
+        self.output.push('\n');
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_thematic_break(&mut self) {
+        self.ensure_newline();
+        self.output.push_str("#line(length: 100%)\n");
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_blockquote(&mut self, b: &crate::mdast::Blockquote) {
+        self.ensure_newline();
+        let body = self.render_isolated(&b.children);
+        self.output.push_str("#quote(block: true)[\n");
+        self.output.push_str(&indent_continuation(&body, 2));
+        self.output.push_str("\n]\n");
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_code(&mut self, c: &crate::mdast::Code) {
+        self.ensure_newline();
+        let value;
+        let code = if c.lang.as_deref() == Some("r") && c.meta.as_deref() == Some("hidden") {
+            value = format!("#| echo: false\n#| results: hide\n{}", c.value);
+            &value
+        } else if c.lang.as_deref() == Some("r") && c.meta.as_deref() != Some("executable") {
+            value = format!("#| eval: false\n{}", c.value);
+            &value
+        } else {
+            &c.value
+        };
+        self.output.push_str(&raw_block(code, c.lang.as_deref()));
+        self.output.push('\n');
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_list(&mut self, l: &crate::mdast::List, base_indent: usize) {
+        self.ensure_newline();
+        let mut number = l.start.unwrap_or(1);
+        for child in &l.children {
+            let Node::ListItem(item) = child else {
+                continue;
+            };
+            let marker = if l.ordered {
+                let marker = format!("{number}. ");
+                number += 1;
+                marker
+            } else {
+                "- ".to_owned()
+            };
+            let indent = base_indent + marker.len();
+
+            for _ in 0..base_indent {
+                self.output.push(' ');
+            }
+            self.output.push_str(&marker);
+            self.at_line_start = false;
+
+            for (i, item_child) in item.children.iter().enumerate() {
+                match item_child {
+                    Node::Paragraph(p) => {
+                        if i > 0 {
+                            // A single newline is a soft line break in Typst;
+                            // retain the source paragraph boundary explicitly.
+                            self.output.push_str("\n\n");
+                            for _ in 0..indent {
+                                self.output.push(' ');
+                            }
+                        }
+                        for c in &p.children {
+                            self.write_node(c);
+                        }
+                    }
+                    Node::List(nested) => {
+                        // A blank line here would close the enclosing item, so
+                        // the nested list starts on the very next line.
+                        self.output.push('\n');
+                        self.at_line_start = true;
+                        self.write_list(nested, indent);
+                        continue;
+                    }
+                    other => {
+                        if i > 0 {
+                            self.output.push('\n');
+                            for _ in 0..indent {
+                                self.output.push(' ');
+                            }
+                        }
+                        let rendered = self.render_isolated(std::slice::from_ref(other));
+                        self.output
+                            .push_str(&indent_continuation(&rendered, indent));
+                    }
+                }
+            }
+            if !self.at_line_start {
+                self.output.push('\n');
+            }
+            self.at_line_start = true;
+        }
+        self.at_line_start = true;
+    }
+
+    /// Rd `\tabular{}` has no header row, so this is a plain grid.
+    pub(super) fn write_table(&mut self, t: &crate::mdast::Table) {
+        self.ensure_newline();
+
+        let rows: Vec<&crate::mdast::TableRow> = t
+            .children
+            .iter()
+            .filter_map(|node| match node {
+                Node::TableRow(row) => Some(row),
+                _ => None,
+            })
+            .collect();
+        if rows.is_empty() {
+            return;
+        }
+        let columns = rows.iter().map(|row| row.children.len()).max().unwrap_or(0);
+
+        self.output
+            .push_str(&format!("#table(\n  columns: {columns},\n"));
+        if t.align.iter().any(Option::is_some) {
+            let align: Vec<_> = (0..columns)
+                .map(|i| match t.align.get(i).copied().flatten() {
+                    Some(Align::Left) => "left",
+                    Some(Align::Center) => "center",
+                    Some(Align::Right) => "right",
+                    None => "auto",
+                })
+                .collect();
+            self.output
+                .push_str(&format!("  align: ({},),\n", align.join(", ")));
+        }
+
+        for row in rows {
+            let mut line = String::from("  ");
+            for cell in &row.children {
+                let Node::TableCell(cell) = cell else {
+                    continue;
+                };
+                line.push_str(&self.cell_content(&cell.children));
+                line.push_str(", ");
+            }
+            for _ in row.children.len()..columns {
+                line.push_str("[], ");
+            }
+            let line = line.trim_end();
+            self.output.push_str(line);
+            self.output.push('\n');
+        }
+        self.output.push_str(")\n");
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_definition_list(&mut self, dl: &crate::mdast::DefinitionList) {
+        self.ensure_newline();
+        let mut entries: Vec<(String, Vec<Node>)> = Vec::new();
+
+        let mut i = 0;
+        while i < dl.children.len() {
+            let Node::DefinitionTerm(term) = &dl.children[i] else {
+                i += 1;
+                continue;
+            };
+            let term = self.cell_content(&term.children);
+            let mut description = Vec::new();
+            i += 1;
+            while let Some(Node::DefinitionDescription(d)) = dl.children.get(i) {
+                description.extend(d.children.iter().cloned());
+                i += 1;
+            }
+            entries.push((term, description));
+        }
+
+        if entries.is_empty() {
+            return;
+        }
+
+        self.output.push_str("#terms(\n");
+        for (term, description) in entries {
+            let description = self.cell_content(&description);
+            self.output
+                .push_str(&format!("  terms.item({term}, {description}),\n"));
+        }
+        self.output.push_str(")\n");
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_arguments(&mut self, arguments: &Arguments) {
+        if arguments.items.is_empty() {
+            return;
+        }
+        self.ensure_newline();
+        match self.options.arguments_format {
+            // Every table variant of the Markdown writer exists to work
+            // around a Markdown table limitation (pipe tables cannot hold
+            // block content, list-tables need Quarto). Typst's own table
+            // holds arbitrary content, so all three map to one rendering.
+            ArgumentsFormat::PipeTable
+            | ArgumentsFormat::GridTable
+            | ArgumentsFormat::ListTable => self.write_arguments_table(&arguments.items),
+            ArgumentsFormat::List => self.write_arguments_terms(&arguments.items),
+        }
+    }
+
+    fn write_arguments_table(&mut self, items: &[ArgumentItem]) {
+        self.output.push_str("#table(\n  columns: 2,\n");
+        self.output
+            .push_str("  table.header([Argument], [Description]),\n");
+        for item in items {
+            let name = super::inline::raw_span(item.name.trim());
+            let description = self.cell_content(&item.description);
+            self.output
+                .push_str(&format!("  [{name}], {description},\n"));
+        }
+        self.output.push_str(")\n");
+        self.at_line_start = true;
+    }
+
+    fn write_arguments_terms(&mut self, items: &[ArgumentItem]) {
+        self.output.push_str("#terms(\n");
+        for item in items {
+            let name = super::inline::raw_span(item.name.trim());
+            let description = self.cell_content(&item.description);
+            self.output
+                .push_str(&format!("  terms.item[{name}]{description},\n"));
+        }
+        self.output.push_str(")\n");
+        self.at_line_start = true;
+    }
+
+    /// Render nodes as a `[..]` content block suitable for a table cell or a
+    /// `terms.item` argument, indented to sit inside the surrounding call.
+    pub(crate) fn cell_content(&self, nodes: &[Node]) -> String {
+        if nodes.is_empty() {
+            return "[]".to_owned();
+        }
+        let rendered = self.render_isolated(nodes);
+        if rendered.contains('\n') {
+            format!("[\n    {}\n  ]", indent_continuation(&rendered, 4))
+        } else {
+            format!("[{rendered}]")
+        }
+    }
+}

--- a/crates/rd2qmd-mdast/src/typst/html.rs
+++ b/crates/rd2qmd-mdast/src/typst/html.rs
@@ -1,0 +1,151 @@
+//! Raw-HTML handling for the Typst writer.
+//!
+//! Rd's `\out{}` (and `\if{html}{}`, when HTML output is enabled) yields a
+//! fragment of literal HTML. Typst has no way to splice an unparsed HTML
+//! string into a document, but since 0.15 it can *build* HTML elements with
+//! `html.elem` when compiling for the HTML export target.
+//!
+//! So a fragment that is one simple element is re-expressed as an
+//! `html.elem` call, wrapped in a `target()` check so that compiling the
+//! same file to PDF neither fails nor emits markup. Anything more involved
+//! than a single element (nested tags, multiple siblings, comments) is kept
+//! verbatim as raw text rather than dropped, so no content goes missing.
+
+use super::{TypstWriter, typst_string};
+
+impl TypstWriter<'_> {
+    pub(super) fn write_html(&mut self, h: &crate::mdast::Html) {
+        let value = h.value.trim();
+        if value.is_empty() {
+            return;
+        }
+        match parse_simple_element(value) {
+            Some(element) => {
+                self.output.push_str(&render_html_elem(&element));
+            }
+            None if !value.contains(['<', '>']) => {
+                let decoded = html_escape::decode_html_entities(value);
+                self.output.push_str(&super::escape_text(&decoded));
+            }
+            None => {
+                self.output
+                    .push_str(&format!("#raw({})", typst_string(value)));
+            }
+        }
+        self.at_line_start = false;
+    }
+}
+
+/// One HTML element with no nested elements in its body.
+struct SimpleElement {
+    tag: String,
+    attributes: Vec<(String, String)>,
+    body: Option<String>,
+}
+
+/// Emit `html.elem`, guarded so the same document still compiles to PDF.
+fn render_html_elem(element: &SimpleElement) -> String {
+    let mut call = format!("html.elem({}", typst_string(&element.tag));
+    if !element.attributes.is_empty() {
+        let attributes: Vec<_> = element
+            .attributes
+            .iter()
+            .map(|(name, value)| format!("{}: {}", attribute_key(name), typst_string(value)))
+            .collect();
+        call.push_str(&format!(", attrs: ({})", attributes.join(", ")));
+    }
+    call.push(')');
+    if let Some(body) = &element.body
+        && !body.is_empty()
+    {
+        call.push_str(&format!("[{}]", super::escape_text(body)));
+    }
+    format!("#context {{ if target() == \"html\" {{ {call} }} }}")
+}
+
+/// Quote an attribute name that is not a bare Typst identifier
+/// (`aria-label`, `data-x`, ...).
+fn attribute_key(name: &str) -> String {
+    let bare = !name.is_empty()
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !name.starts_with(|c: char| c.is_ascii_digit());
+    if bare {
+        name.to_owned()
+    } else {
+        typst_string(name)
+    }
+}
+
+/// Parse `<tag attr="value">text</tag>`, `<tag/>`, or `<tag>`.
+///
+/// Deliberately narrow: it recognizes exactly the shapes that appear in
+/// practice in `\out{}` (`<br>`, `<sup>2</sup>`, `<span class="x">text</span>`)
+/// and gives up on anything else rather than half-parsing HTML.
+fn parse_simple_element(value: &str) -> Option<SimpleElement> {
+    let rest = value.strip_prefix('<')?;
+    if rest.starts_with('/') || rest.starts_with('!') {
+        return None;
+    }
+    let (open_tag, rest) = rest.split_once('>')?;
+    let open_tag = open_tag.trim();
+    let (open_tag, self_closing) = match open_tag.strip_suffix('/') {
+        Some(stripped) => (stripped.trim_end(), true),
+        None => (open_tag, false),
+    };
+
+    let (tag, attribute_text) = match open_tag.find(char::is_whitespace) {
+        Some(index) => (&open_tag[..index], open_tag[index..].trim()),
+        None => (open_tag, ""),
+    };
+    if tag.is_empty() || !tag.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return None;
+    }
+    let attributes = parse_attributes(attribute_text)?;
+
+    if self_closing || rest.is_empty() {
+        return Some(SimpleElement {
+            tag: tag.to_owned(),
+            attributes,
+            body: None,
+        });
+    }
+
+    // A body containing further markup is out of scope.
+    let closing = format!("</{tag}>");
+    let body = rest.strip_suffix(&closing)?;
+    if body.contains('<') || body.contains('>') {
+        return None;
+    }
+
+    Some(SimpleElement {
+        tag: tag.to_owned(),
+        attributes,
+        body: Some(html_escape::decode_html_entities(body).into_owned()),
+    })
+}
+
+/// Parse `name="value"` pairs. Unquoted or valueless attributes are not
+/// recognized, which makes the whole fragment fall back to raw text.
+fn parse_attributes(text: &str) -> Option<Vec<(String, String)>> {
+    let mut attributes = Vec::new();
+    let mut rest = text.trim();
+    while !rest.is_empty() {
+        let (name, tail) = rest.split_once('=')?;
+        let name = name.trim();
+        if name.is_empty() || name.contains(char::is_whitespace) {
+            return None;
+        }
+        let tail = tail.trim_start();
+        let quote = tail.chars().next()?;
+        if quote != '"' && quote != '\'' {
+            return None;
+        }
+        let (value, tail) = tail[1..].split_once(quote)?;
+        attributes.push((
+            name.to_owned(),
+            html_escape::decode_html_entities(value).into_owned(),
+        ));
+        rest = tail.trim_start();
+    }
+    Some(attributes)
+}

--- a/crates/rd2qmd-mdast/src/typst/inline.rs
+++ b/crates/rd2qmd-mdast/src/typst/inline.rs
@@ -1,0 +1,125 @@
+//! Inline-level Typst writers.
+
+use super::{TypstWriter, typst_string};
+use crate::mdast::Node;
+
+impl TypstWriter<'_> {
+    pub(super) fn write_emphasis(&mut self, e: &crate::mdast::Emphasis) {
+        self.output.push_str("#emph");
+        self.write_content_block(&e.children);
+    }
+
+    pub(super) fn write_strong(&mut self, s: &crate::mdast::Strong) {
+        self.output.push_str("#strong");
+        self.write_content_block(&s.children);
+    }
+
+    pub(super) fn write_inline_code(&mut self, c: &crate::mdast::InlineCode) {
+        self.output.push_str(&raw_span(&c.value));
+        self.at_line_start = false;
+    }
+
+    pub(super) fn write_break(&mut self) {
+        // Typst's forced line break.
+        self.output.push_str(" \\\n");
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_link(&mut self, l: &crate::mdast::Link) {
+        self.output.push_str("#link(");
+        self.output.push_str(&typst_string(&l.url));
+        self.output.push(')');
+        // `#link("url")` alone renders the URL itself, so the content block is
+        // only needed when the label differs from the destination.
+        let label_is_url = matches!(l.children.as_slice(), [Node::Text(t)] if t.value == l.url);
+        if !label_is_url {
+            self.write_content_block(&l.children);
+        }
+        self.at_line_start = false;
+    }
+
+    pub(super) fn write_image(&mut self, img: &crate::mdast::Image) {
+        self.output.push_str("#image(");
+        self.output.push_str(&typst_string(&img.url));
+        if !img.alt.is_empty() {
+            self.output.push_str(", alt: ");
+            self.output.push_str(&typst_string(&img.alt));
+        }
+        self.output.push(')');
+        self.at_line_start = false;
+    }
+
+    /// Rd equations are LaTeX, which Typst's own math mode cannot read, so
+    /// they go through MiTeX.
+    pub(super) fn write_math(&mut self, m: &crate::mdast::Math) {
+        self.ensure_newline();
+        self.output.push_str("#mitex(");
+        self.output.push_str(&latex_argument(&m.value));
+        self.output.push_str(")\n");
+        self.at_line_start = true;
+    }
+
+    pub(super) fn write_inline_math(&mut self, m: &crate::mdast::InlineMath) {
+        self.output.push_str("#mi(");
+        self.output.push_str(&latex_argument(&m.value));
+        self.output.push(')');
+        self.at_line_start = false;
+    }
+}
+
+/// Render a LaTeX fragment as a MiTeX argument.
+///
+/// A raw block is preferred, since LaTeX is mostly backslashes and a raw
+/// block needs no escaping at all; a fragment containing a backtick falls
+/// back to a string literal.
+fn latex_argument(value: &str) -> String {
+    let value = value.trim();
+    if value.contains('`') {
+        typst_string(value)
+    } else {
+        format!("`{value}`")
+    }
+}
+
+/// Render a value as inline Typst raw text.
+///
+/// Typst raw spans are delimited by a single backtick (or three, which also
+/// consume a leading language tag), so a value containing a backtick cannot
+/// be expressed as a span and uses `#raw` instead.
+pub(super) fn raw_span(value: &str) -> String {
+    if value.contains('`') {
+        return format!("#raw({})", typst_string(value));
+    }
+    // A leading or trailing space would be trimmed by the raw span.
+    if value.starts_with(' ') || value.ends_with(' ') {
+        return format!("#raw({})", typst_string(value));
+    }
+    format!("`{value}`")
+}
+
+/// Render a value as a Typst raw block with an optional language tag.
+///
+/// R code is emitted as a plain ```` ```r ```` block: Typst renders it as a
+/// highlighted listing, and calepin can execute the same block.
+pub(super) fn raw_block(value: &str, lang: Option<&str>) -> String {
+    let value = value.strip_suffix('\n').unwrap_or(value);
+    // Typst raw blocks are always three backticks, with no longer-fence
+    // escape hatch: a run of three inside the content closes the block early
+    // (and even where it currently parses, Typst warns that a future version
+    // will read what follows as a language tag). Fall back to `#raw`.
+    if value.contains("```") {
+        let lang_argument = lang
+            .map(|lang| format!("lang: {}, ", typst_string(lang)))
+            .unwrap_or_default();
+        return format!("#raw(block: true, {lang_argument}{})", typst_string(value));
+    }
+    let mut out = String::from("```");
+    if let Some(lang) = lang {
+        out.push_str(lang);
+    }
+    out.push('\n');
+    out.push_str(value);
+    out.push('\n');
+    out.push_str("```");
+    out
+}

--- a/crates/rd2qmd-mdast/src/typst/mod.rs
+++ b/crates/rd2qmd-mdast/src/typst/mod.rs
@@ -1,0 +1,404 @@
+//! mdast to Typst writer.
+//!
+//! Renders the same mdast tree as the Markdown writer into Typst markup
+//! (`.typ`), which compiles to PDF and -- with Typst 0.15's experimental
+//! `--features html --format html` target -- to HTML.
+//!
+//! Three conventions are worth stating up front:
+//!
+//! * **Math.** Rd `\eqn{}`/`\deqn{}` bodies are LaTeX, and Typst math is not
+//!   LaTeX, so equations are emitted as [MiTeX] calls (`#mi` inline,
+//!   `#mitex` block) and the import is added only to documents that contain
+//!   math.
+//! * **Code.** R code is written as a plain ```` ```r ```` raw block, never
+//!   an executable one. Under plain `typst` it renders as a highlighted
+//!   listing; under [calepin] the same block can be executed.
+//! * **Raw HTML.** `\out{}` content is emitted through `html.elem`, guarded
+//!   by `target()` so PDF compilation of the same file still works.
+//!
+//! [MiTeX]: https://typst.app/universe/package/mitex/
+//! [calepin]: https://vincentarelbundock.github.io/calepin/
+
+use crate::mdast::{ArgumentItem, Node, Root};
+use crate::writer::{ArgumentsFormat, Frontmatter};
+
+mod block;
+mod html;
+mod inline;
+#[cfg(test)]
+mod tests;
+
+/// Version of the MiTeX package imported by documents containing math.
+pub const MITEX_VERSION: &str = "0.2.7";
+
+/// Options for the Typst writer.
+#[derive(Debug, Clone, Default)]
+pub struct TypstWriterOptions {
+    /// Document metadata. Rendered as `#set document(..)` plus a queryable
+    /// `#metadata(..)<rd2qmd>` block, and as a visible title heading.
+    pub frontmatter: Option<Frontmatter>,
+    /// Physical rendering of the Arguments section.
+    pub arguments_format: ArgumentsFormat,
+}
+
+/// Convert mdast to Typst markup.
+pub fn mdast_to_typst(root: &Root, options: &TypstWriterOptions) -> String {
+    let mut writer = TypstWriter::new(options);
+    writer.write_root(root)
+}
+
+/// Typst writer state.
+pub(crate) struct TypstWriter<'a> {
+    pub(crate) options: &'a TypstWriterOptions,
+    pub(crate) output: String,
+    pub(crate) at_line_start: bool,
+}
+
+impl<'a> TypstWriter<'a> {
+    fn new(options: &'a TypstWriterOptions) -> Self {
+        Self {
+            options,
+            output: String::new(),
+            at_line_start: true,
+        }
+    }
+
+    fn write_root(&mut self, root: &Root) -> String {
+        if contains_math(&root.children) {
+            self.output.push_str(&format!(
+                "#import \"@preview/mitex:{MITEX_VERSION}\": mi, mitex\n"
+            ));
+        }
+        if let Some(frontmatter) = &self.options.frontmatter {
+            self.write_frontmatter(frontmatter);
+        }
+
+        for node in &root.children {
+            self.ensure_blank_line();
+            self.write_node(node);
+        }
+
+        // Exactly one trailing newline.
+        while self.output.ends_with("\n\n") {
+            self.output.pop();
+        }
+        if !self.output.ends_with('\n') && !self.output.is_empty() {
+            self.output.push('\n');
+        }
+        self.output.clone()
+    }
+
+    /// Emit document metadata: `#set document` for the compiler and PDF/HTML
+    /// metadata, a queryable `#metadata(..)<rd2qmd>` for tooling, and a
+    /// visible title heading (Typst, unlike Quarto, renders nothing from
+    /// document metadata on its own).
+    fn write_frontmatter(&mut self, frontmatter: &Frontmatter) {
+        if let Some(title) = &frontmatter.title {
+            self.output
+                .push_str(&format!("#set document(title: {})\n", typst_string(title)));
+        }
+
+        let mut fields: Vec<(&str, String)> = Vec::new();
+        if let Some(pagetitle) = &frontmatter.pagetitle {
+            fields.push(("pagetitle", typst_string(pagetitle)));
+        }
+        if let Some(metadata) = &frontmatter.metadata {
+            if let Some(lifecycle) = &metadata.lifecycle {
+                fields.push(("lifecycle", typst_string(lifecycle)));
+            }
+            for (key, values) in [
+                ("aliases", &metadata.aliases),
+                ("keywords", &metadata.keywords),
+                ("concepts", &metadata.concepts),
+                ("source-files", &metadata.source_files),
+            ] {
+                if !values.is_empty() {
+                    fields.push((key, typst_string_array(values)));
+                }
+            }
+        }
+        if !fields.is_empty() {
+            self.output.push_str("#metadata((\n");
+            for (key, value) in fields {
+                // `source-files` is not a bare Typst identifier.
+                let key = if key.contains('-') {
+                    typst_string(key)
+                } else {
+                    key.to_owned()
+                };
+                self.output.push_str(&format!("  {key}: {value},\n"));
+            }
+            self.output.push_str("))<rd2qmd>\n");
+        }
+
+        if let Some(title) = &frontmatter.title {
+            self.output.push('\n');
+            self.output.push_str("= ");
+            self.output.push_str(&escape_text(title));
+            self.output.push('\n');
+        }
+        self.at_line_start = true;
+    }
+
+    pub(crate) fn write_node(&mut self, node: &Node) {
+        match node {
+            // Block nodes
+            Node::Heading(h) => self.write_heading(h),
+            Node::Paragraph(p) => self.write_paragraph(p),
+            Node::ThematicBreak => self.write_thematic_break(),
+            Node::Blockquote(b) => self.write_blockquote(b),
+            Node::List(l) => self.write_list(l, 0),
+            Node::ListItem(_) => {} // Handled by write_list
+            Node::Code(c) => self.write_code(c),
+            Node::Table(t) => self.write_table(t),
+            Node::TableRow(_) => {}  // Handled by write_table
+            Node::TableCell(_) => {} // Handled by write_table
+            Node::DefinitionList(dl) => self.write_definition_list(dl),
+            Node::DefinitionTerm(_) => {} // Handled by write_definition_list
+            Node::DefinitionDescription(_) => {} // Handled by write_definition_list
+            Node::Arguments(a) => self.write_arguments(a),
+
+            // Inline nodes
+            Node::Text(t) => {
+                let escaped = escape_text_at(&t.value, self.at_line_start);
+                self.output.push_str(&escaped);
+                // Whitespace does not end the start-of-line state: Typst reads
+                // an indented `-` as a list marker too, and inline text often
+                // arrives split across several Text nodes.
+                if !escaped.trim().is_empty() || escaped.contains('\n') {
+                    self.at_line_start = escaped.ends_with('\n');
+                }
+            }
+            Node::Emphasis(e) => self.write_emphasis(e),
+            Node::Strong(s) => self.write_strong(s),
+            Node::InlineCode(c) => self.write_inline_code(c),
+            Node::Break => self.write_break(),
+            Node::Link(l) => self.write_link(l),
+            Node::Image(i) => self.write_image(i),
+            Node::Math(m) => self.write_math(m),
+            Node::InlineMath(m) => self.write_inline_math(m),
+            Node::Html(h) => self.write_html(h),
+        }
+    }
+
+    /// Write inline children into a `[..]` content block.
+    pub(crate) fn write_content_block(&mut self, children: &[Node]) {
+        self.output.push('[');
+        self.at_line_start = false;
+        for child in children {
+            self.write_node(child);
+        }
+        self.output.push(']');
+        self.at_line_start = false;
+    }
+
+    /// Render nodes to a standalone Typst string, isolated from the current
+    /// output buffer's line state.
+    ///
+    /// Blank lines separate block nodes only: inline siblings (a table cell
+    /// is a flat run of them) must stay on one line.
+    pub(crate) fn render_isolated(&self, nodes: &[Node]) -> String {
+        let mut writer = TypstWriter::new(self.options);
+        for (i, node) in nodes.iter().enumerate() {
+            if i > 0 && (is_block(node) || is_block(&nodes[i - 1])) {
+                writer.ensure_blank_line();
+            }
+            writer.write_node(node);
+        }
+        writer.output.trim().to_owned()
+    }
+
+    pub(crate) fn ensure_newline(&mut self) {
+        if !self.at_line_start && !self.output.is_empty() {
+            self.output.push('\n');
+            self.at_line_start = true;
+        }
+    }
+
+    pub(crate) fn ensure_blank_line(&mut self) {
+        self.ensure_newline();
+        if !self.output.ends_with("\n\n") && !self.output.is_empty() {
+            self.output.push('\n');
+        }
+    }
+}
+
+/// Whether a node is block-level, and so needs its own line.
+fn is_block(node: &Node) -> bool {
+    matches!(
+        node,
+        Node::Heading(_)
+            | Node::Paragraph(_)
+            | Node::ThematicBreak
+            | Node::Blockquote(_)
+            | Node::List(_)
+            | Node::ListItem(_)
+            | Node::Code(_)
+            | Node::Table(_)
+            | Node::DefinitionList(_)
+            | Node::Arguments(_)
+            | Node::Math(_)
+    )
+}
+
+/// Whether any node in the tree is math, i.e. whether MiTeX must be imported.
+fn contains_math(nodes: &[Node]) -> bool {
+    nodes.iter().any(|node| match node {
+        Node::Math(_) | Node::InlineMath(_) => true,
+        Node::Heading(n) => contains_math(&n.children),
+        Node::Paragraph(n) => contains_math(&n.children),
+        Node::Blockquote(n) => contains_math(&n.children),
+        Node::List(n) => contains_math(&n.children),
+        Node::ListItem(n) => contains_math(&n.children),
+        Node::Table(n) => contains_math(&n.children),
+        Node::TableRow(n) => contains_math(&n.children),
+        Node::TableCell(n) => contains_math(&n.children),
+        Node::DefinitionList(n) => contains_math(&n.children),
+        Node::DefinitionTerm(n) => contains_math(&n.children),
+        Node::DefinitionDescription(n) => contains_math(&n.children),
+        Node::Emphasis(n) => contains_math(&n.children),
+        Node::Strong(n) => contains_math(&n.children),
+        Node::Link(n) => contains_math(&n.children),
+        Node::Arguments(n) => n
+            .items
+            .iter()
+            .any(|item: &ArgumentItem| contains_math(&item.description)),
+        _ => false,
+    })
+}
+
+/// Escape a Typst string literal, including the surrounding quotes.
+pub(crate) fn typst_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(character),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn typst_string_array(values: &[String]) -> String {
+    let items: Vec<_> = values.iter().map(|value| typst_string(value)).collect();
+    // A one-element Typst array needs a trailing comma to stay an array.
+    if items.len() == 1 {
+        format!("({},)", items[0])
+    } else {
+        format!("({})", items.join(", "))
+    }
+}
+
+/// Escape text for Typst markup, assuming it is not at the start of a line.
+pub(crate) fn escape_text(value: &str) -> String {
+    escape_text_at(value, false)
+}
+
+/// Escape text for Typst markup.
+///
+/// Two classes of character need escaping. The first is special anywhere:
+/// `\` (escape), `#` (code), `$` (math), `*`/`_` (strong/emph), `` ` ``
+/// (raw), `<`/`>` (labels), `@` (references), `~` (non-breaking space) and
+/// `[`/`]` (content blocks), and parentheses (which can call the preceding
+/// content expression). The second is special only at the start of a
+/// line, where it would begin a heading, list, or term: `=`, `-`, `+`, `/`
+/// and a digit run followed by `.`.
+pub(crate) fn escape_text_at(value: &str, at_line_start: bool) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut line_start = at_line_start;
+
+    let mut chars = value.chars().peekable();
+    while let Some(character) = chars.next() {
+        if line_start {
+            // Leading whitespace does not end the "start of line" state:
+            // Typst treats an indented `-` as a list marker too.
+            if character == ' ' || character == '\t' {
+                out.push(character);
+                continue;
+            }
+            match character {
+                '=' | '-' | '+' | '/' => {
+                    out.push('\\');
+                    out.push(character);
+                    line_start = false;
+                    continue;
+                }
+                '0'..='9' => {
+                    // A digit run followed by `.` starts an enumeration.
+                    let mut digits = String::from(character);
+                    while let Some(next) = chars.peek().copied() {
+                        if next.is_ascii_digit() {
+                            digits.push(next);
+                            chars.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    out.push_str(&digits);
+                    if chars.peek() == Some(&'.') {
+                        chars.next();
+                        out.push_str("\\.");
+                    }
+                    line_start = false;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        match character {
+            // A period immediately following a `#function(..)` expression is
+            // parsed as field access. Escaping every prose period is harmless
+            // and keeps Text nodes safe regardless of their previous sibling.
+            '\\' | '#' | '$' | '*' | '_' | '`' | '<' | '>' | '@' | '~' | '[' | ']' | '(' | ')'
+            | '.' => {
+                out.push('\\');
+                out.push(character);
+                line_start = false;
+            }
+            // Typst turns `--` and `---` into en/em dashes. Rd prose often
+            // contains CLI flags and literal numeric ranges, so preserve runs.
+            '-' if chars.peek() == Some(&'-') => {
+                out.push('\\');
+                out.push(character);
+                while chars.peek() == Some(&'-') {
+                    out.push('\\');
+                    out.push(chars.next().expect("peeked hyphen must exist"));
+                }
+                line_start = false;
+            }
+            '\n' => {
+                out.push('\n');
+                line_start = true;
+            }
+            _ => {
+                out.push(character);
+                line_start = false;
+            }
+        }
+    }
+
+    out
+}
+
+/// Indent every line after the first by `indent` spaces.
+pub(crate) fn indent_continuation(value: &str, indent: usize) -> String {
+    let pad = " ".repeat(indent);
+    let mut out = String::with_capacity(value.len());
+    for (i, line) in value.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+            if !line.is_empty() {
+                out.push_str(&pad);
+            }
+        }
+        out.push_str(line);
+    }
+    out
+}

--- a/crates/rd2qmd-mdast/src/typst/tests.rs
+++ b/crates/rd2qmd-mdast/src/typst/tests.rs
@@ -1,0 +1,402 @@
+use super::*;
+use crate::mdast::*;
+use crate::writer::{ArgumentsFormat, RdMetadata};
+
+fn typst(nodes: Vec<Node>) -> String {
+    mdast_to_typst(&Root::new(nodes), &TypstWriterOptions::default())
+}
+
+fn typst_with(nodes: Vec<Node>, options: &TypstWriterOptions) -> String {
+    mdast_to_typst(&Root::new(nodes), options)
+}
+
+#[test]
+fn writes_headings_and_paragraphs() {
+    let output = typst(vec![
+        Node::heading(1, vec![Node::text("Title")]),
+        Node::paragraph(vec![Node::text("Body text.")]),
+        Node::heading(3, vec![Node::text("Deep")]),
+    ]);
+    assert_eq!(output, "= Title\n\nBody text\\.\n\n=== Deep\n");
+}
+
+#[test]
+fn writes_emphasis_strong_and_inline_code() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::emphasis(vec![Node::text("em")]),
+        Node::text(" "),
+        Node::strong(vec![Node::text("strong")]),
+        Node::text(" "),
+        Node::inline_code("x <- 1"),
+    ])]);
+    assert_eq!(output, "#emph[em] #strong[strong] `x <- 1`\n");
+}
+
+#[test]
+fn emphasis_and_strong_are_safe_next_to_word_characters() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::text("non"),
+        Node::emphasis(vec![Node::text("linear")]),
+        Node::text(" and word"),
+        Node::strong(vec![Node::text("strong")]),
+    ])]);
+    assert_eq!(output, "non#emph[linear] and word#strong[strong]\n");
+}
+
+#[test]
+fn emphasis_is_safe_before_parenthesized_text() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::emphasis(vec![Node::text("111")]),
+        Node::text("(9)"),
+    ])]);
+    assert_eq!(output, "#emph[111]\\(9\\)\n");
+}
+
+#[test]
+fn escapes_typst_syntax_characters_in_text() {
+    let output = typst(vec![Node::paragraph(vec![Node::text(
+        "a #b $c *d _e `f <g> @h ~i [j]",
+    )])]);
+    assert_eq!(
+        output,
+        "a \\#b \\$c \\*d \\_e \\`f \\<g\\> \\@h \\~i \\[j\\]\n"
+    );
+}
+
+#[test]
+fn escapes_only_line_leading_markup_characters() {
+    // `-`, `+`, `=`, `/` and `1.` start a list, heading or term at the start
+    // of a line, but are ordinary text anywhere else.
+    let output = typst(vec![
+        Node::paragraph(vec![Node::text("- leading hyphen")]),
+        Node::paragraph(vec![Node::text("mid - hyphen")]),
+        Node::paragraph(vec![Node::text("1. ordered")]),
+        Node::paragraph(vec![Node::text("value 1. mid")]),
+    ]);
+    assert_eq!(
+        output,
+        "\\- leading hyphen\n\nmid - hyphen\n\n1\\. ordered\n\nvalue 1\\. mid\n"
+    );
+}
+
+#[test]
+fn a_line_break_restores_line_start_escaping() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::text("first"),
+        Node::line_break(),
+        Node::text("- second"),
+    ])]);
+    assert_eq!(output, "first \\\n\\- second\n");
+}
+
+#[test]
+fn writes_links_and_images() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::link("https://example.com/a.html", vec![Node::text("label")]),
+        Node::text(" "),
+        Node::image("figure.png", "alt text"),
+    ])]);
+    assert_eq!(
+        output,
+        "#link(\"https://example.com/a.html\")[label] #image(\"figure.png\", alt: \"alt text\")\n"
+    );
+}
+
+#[test]
+fn escapes_periods_after_typst_function_calls_and_dash_shorthands() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::link("https://example.com", vec![Node::text("site")]),
+        Node::text(".tar.gz --vanilla 1---3"),
+    ])]);
+    assert_eq!(
+        output,
+        "#link(\"https://example.com\")[site]\\.tar\\.gz \\-\\-vanilla 1\\-\\-\\-3\n"
+    );
+}
+
+#[test]
+fn a_self_labelled_link_needs_no_content_block() {
+    let output = typst(vec![Node::paragraph(vec![Node::link(
+        "https://example.com",
+        vec![Node::text("https://example.com")],
+    )])]);
+    assert_eq!(output, "#link(\"https://example.com\")\n");
+}
+
+#[test]
+fn writes_r_code_as_a_plain_raw_block() {
+    // Never `{r}`: Typst has no executable blocks, and calepin executes a
+    // plain ```r block.
+    let output = typst(vec![Node::code_with_meta(
+        Some("r".to_owned()),
+        Some("executable".to_owned()),
+        "plot(1:10)",
+    )]);
+    assert_eq!(output, "```r\nplot(1:10)\n```\n");
+}
+
+#[test]
+fn marks_non_executable_r_code_for_calepin() {
+    let output = typst(vec![Node::code(Some("r".to_owned()), "function(x)")]);
+    assert_eq!(output, "```r\n#| eval: false\nfunction(x)\n```\n");
+}
+
+#[test]
+fn hides_setup_code_but_keeps_it_executable_for_calepin() {
+    let output = typst(vec![Node::code_with_meta(
+        Some("r".to_owned()),
+        Some("hidden".to_owned()),
+        "setup()",
+    )]);
+    assert_eq!(
+        output,
+        "```r\n#| echo: false\n#| results: hide\nsetup()\n```\n"
+    );
+}
+
+#[test]
+fn code_containing_a_fence_falls_back_to_the_raw_function() {
+    // Typst raw blocks have no longer-fence escape hatch.
+    let output = typst(vec![Node::code_with_meta(
+        Some("r".to_owned()),
+        Some("executable".to_owned()),
+        "x <- \"```triple```\"",
+    )]);
+    assert_eq!(
+        output,
+        "#raw(block: true, lang: \"r\", \"x <- \\\"```triple```\\\"\")\n"
+    );
+}
+
+#[test]
+fn inline_code_containing_a_backtick_falls_back_to_the_raw_function() {
+    let output = typst(vec![Node::paragraph(vec![Node::inline_code("`a`")])]);
+    assert_eq!(output, "#raw(\"`a`\")\n");
+}
+
+#[test]
+fn writes_latex_math_through_mitex_and_imports_it_once() {
+    let output = typst(vec![
+        Node::paragraph(vec![Node::inline_math("\\alpha_i")]),
+        Node::math("\\sum_{i=1}^{n} x_i"),
+    ]);
+    assert_eq!(
+        output,
+        format!(
+            "#import \"@preview/mitex:{MITEX_VERSION}\": mi, mitex\n\n\
+             #mi(`\\alpha_i`)\n\n\
+             #mitex(`\\sum_{{i=1}}^{{n}} x_i`)\n"
+        )
+    );
+}
+
+#[test]
+fn a_document_without_math_does_not_import_mitex() {
+    let output = typst(vec![Node::paragraph(vec![Node::text("no math")])]);
+    assert!(!output.contains("mitex"));
+}
+
+#[test]
+fn writes_lists_with_nesting() {
+    let output = typst(vec![Node::list(
+        false,
+        vec![
+            Node::list_item(vec![
+                Node::paragraph(vec![Node::text("first")]),
+                Node::list(
+                    true,
+                    vec![Node::list_item(vec![Node::paragraph(vec![Node::text(
+                        "nested",
+                    )])])],
+                ),
+            ]),
+            Node::list_item(vec![Node::paragraph(vec![Node::text("second")])]),
+        ],
+    )]);
+    assert_eq!(output, "- first\n  1. nested\n- second\n");
+}
+
+#[test]
+fn preserves_paragraph_boundaries_inside_list_items() {
+    let output = typst(vec![Node::list(
+        false,
+        vec![Node::list_item(vec![
+            Node::paragraph(vec![Node::text("first")]),
+            Node::paragraph(vec![Node::text("second")]),
+        ])],
+    )]);
+    assert_eq!(output, "- first\n\n  second\n");
+}
+
+#[test]
+fn writes_a_tabular_as_a_typst_table() {
+    let output = typst(vec![Node::table(
+        vec![Some(Align::Left), Some(Align::Right)],
+        vec![
+            Node::table_row(vec![
+                Node::table_cell(vec![Node::text("a")]),
+                Node::table_cell(vec![Node::text("1")]),
+            ]),
+            Node::table_row(vec![
+                Node::table_cell(vec![Node::text("b")]),
+                Node::table_cell(vec![Node::text("2")]),
+            ]),
+        ],
+    )]);
+    assert_eq!(
+        output,
+        "#table(\n  columns: 2,\n  align: (left, right,),\n  [a], [1],\n  [b], [2],\n)\n"
+    );
+}
+
+#[test]
+fn writes_a_definition_list_as_typst_terms() {
+    let output = typst(vec![Node::definition_list(vec![
+        Node::definition_term(vec![Node::inline_code("a")]),
+        Node::definition_description(vec![Node::paragraph(vec![Node::text("first")])]),
+    ])]);
+    assert_eq!(output, "#terms(\n  terms.item([`a`], [first]),\n)\n");
+}
+
+fn arguments_node() -> Node {
+    Node::arguments(vec![
+        ArgumentItem {
+            name: "x".to_owned(),
+            description: vec![Node::paragraph(vec![Node::text("A number.")])],
+        },
+        ArgumentItem {
+            name: "y".to_owned(),
+            description: vec![
+                Node::paragraph(vec![Node::text("Choices:")]),
+                Node::list(
+                    false,
+                    vec![Node::list_item(vec![Node::paragraph(vec![Node::text(
+                        "one",
+                    )])])],
+                ),
+            ],
+        },
+    ])
+}
+
+#[test]
+fn writes_arguments_as_a_table_holding_block_content() {
+    let output = typst(vec![arguments_node()]);
+    assert_eq!(
+        output,
+        "#table(\n  \
+           columns: 2,\n  \
+           table.header([Argument], [Description]),\n  \
+           [`x`], [A number\\.],\n  \
+           [`y`], [\n    Choices:\n\n    - one\n  ],\n\
+         )\n"
+    );
+}
+
+#[test]
+fn every_markdown_table_format_maps_to_one_typst_table() {
+    // The pipe/grid/list-table split exists only to work around Markdown
+    // table limitations that Typst's table does not have.
+    let table = typst_with(
+        vec![arguments_node()],
+        &TypstWriterOptions {
+            arguments_format: ArgumentsFormat::PipeTable,
+            ..TypstWriterOptions::default()
+        },
+    );
+    for format in [ArgumentsFormat::GridTable, ArgumentsFormat::ListTable] {
+        assert_eq!(
+            typst_with(
+                vec![arguments_node()],
+                &TypstWriterOptions {
+                    arguments_format: format,
+                    ..TypstWriterOptions::default()
+                },
+            ),
+            table
+        );
+    }
+}
+
+#[test]
+fn the_list_arguments_format_maps_to_typst_terms() {
+    let output = typst_with(
+        vec![arguments_node()],
+        &TypstWriterOptions {
+            arguments_format: ArgumentsFormat::List,
+            ..TypstWriterOptions::default()
+        },
+    );
+    assert!(output.starts_with("#terms(\n  terms.item[`x`][A number\\.],\n"));
+}
+
+#[test]
+fn writes_a_simple_out_fragment_as_a_guarded_html_elem() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::html("<sup>2</sup>"),
+        Node::text(" "),
+        Node::html("<span class=\"x\">tagged</span>"),
+        Node::text(" "),
+        Node::html("<br>"),
+    ])]);
+    assert_eq!(
+        output,
+        "#context { if target() == \"html\" { html.elem(\"sup\")[2] } } \
+         #context { if target() == \"html\" { html.elem(\"span\", attrs: (class: \"x\"))[tagged] } } \
+         #context { if target() == \"html\" { html.elem(\"br\") } }\n"
+    );
+}
+
+#[test]
+fn decodes_html_entities_in_text_elements_and_attributes() {
+    let output = typst(vec![Node::paragraph(vec![
+        Node::html("Tom &amp; Jerry"),
+        Node::text(" "),
+        Node::html("<span title=\"A &amp; B\">&#169; 2026</span>"),
+    ])]);
+    assert_eq!(
+        output,
+        "Tom & Jerry #context { if target() == \"html\" { html.elem(\"span\", attrs: (title: \"A & B\"))[© 2026] } }\n"
+    );
+}
+
+#[test]
+fn keeps_a_complex_html_fragment_verbatim_instead_of_dropping_it() {
+    let output = typst(vec![Node::paragraph(vec![Node::html(
+        "<div><p>nested</p></div>",
+    )])]);
+    assert_eq!(output, "#raw(\"<div><p>nested</p></div>\")\n");
+}
+
+#[test]
+fn writes_frontmatter_as_document_metadata_and_a_title_heading() {
+    let output = typst_with(
+        vec![Node::paragraph(vec![Node::text("body")])],
+        &TypstWriterOptions {
+            frontmatter: Some(Frontmatter {
+                title: Some("The Title".to_owned()),
+                pagetitle: Some("The Title — topic".to_owned()),
+                format: None,
+                metadata: Some(RdMetadata {
+                    lifecycle: Some("experimental".to_owned()),
+                    aliases: vec!["topic".to_owned(), "topic2".to_owned()],
+                    source_files: vec!["R/topic.R".to_owned()],
+                    ..RdMetadata::default()
+                }),
+            }),
+            ..TypstWriterOptions::default()
+        },
+    );
+    assert_eq!(
+        output,
+        "#set document(title: \"The Title\")\n\
+         #metadata((\n  \
+           pagetitle: \"The Title — topic\",\n  \
+           lifecycle: \"experimental\",\n  \
+           aliases: (\"topic\", \"topic2\"),\n  \
+           \"source-files\": (\"R/topic.R\",),\n\
+         ))<rd2qmd>\n\n\
+         = The Title\n\n\
+         body\n"
+    );
+}

--- a/crates/rd2qmd-mdast/src/writer/arguments.rs
+++ b/crates/rd2qmd-mdast/src/writer/arguments.rs
@@ -1,23 +1,139 @@
-//! Standalone markdown-string rendering used for grid-table / list-table
-//! cells -- a separate code path from the pipe-table flattening in
+//! Markdown rendering of an [`Arguments`] section.
+//!
+//! The Arguments section is the one construct whose physical shape is a user
+//! choice ([`ArgumentsFormat`]), so the converter hands the writer a semantic
+//! node and every rendering decision is made here.
+//!
+//! The standalone markdown-string serializers below are used for grid-table /
+//! list-table cells -- a separate code path from the pipe-table flattening in
 //! [`super::table_cell`], per the doc comment on [`convert_to_markdown_text`].
 
-use rd_ast::RdNode;
-use rd2qmd_mdast::{Node, Root, WriterOptions, mdast_to_qmd};
+use tabled::settings::Style;
+use tabled::settings::style::HorizontalLine;
 
-use super::{BlockConversionContext, convert_block_content};
+use super::table_cell::flatten_for_table_cell;
+use super::{ArgumentsFormat, Writer, WriterOptions, mdast_to_qmd};
+use crate::mdast::{Align, ArgumentItem, Arguments, Node, Root};
 
-/// Convert Rd content to a standalone Markdown string for a grid-table cell.
+impl Writer<'_> {
+    pub(super) fn write_arguments(&mut self, arguments: &Arguments) {
+        if arguments.items.is_empty() {
+            return;
+        }
+        match self.options.arguments_format {
+            ArgumentsFormat::PipeTable => self.write_arguments_pipe(&arguments.items),
+            ArgumentsFormat::GridTable => self.write_arguments_grid(&arguments.items),
+            ArgumentsFormat::ListTable => self.write_arguments_list_table(&arguments.items),
+            ArgumentsFormat::List => self.write_arguments_list(&arguments.items),
+        }
+    }
+
+    /// Pipe table: cannot contain block elements (lists, multiple paragraphs).
+    /// Workaround: use `<br>` for line breaks and flatten lists with bullet markers.
+    fn write_arguments_pipe(&mut self, items: &[ArgumentItem]) {
+        let header_row = Node::table_row(vec![
+            Node::table_cell(vec![Node::text("Argument")]),
+            Node::table_cell(vec![Node::text("Description")]),
+        ]);
+        let mut rows = vec![header_row];
+
+        for item in items {
+            let name = replace_line_endings_with_space(&item.name).replace('|', "\\|");
+            rows.push(Node::table_row(vec![
+                Node::table_cell(vec![Node::inline_code(name.trim())]),
+                Node::table_cell(flatten_for_table_cell(&item.description)),
+            ]));
+        }
+
+        let table = crate::mdast::Table {
+            align: vec![Some(Align::Left), Some(Align::Left)],
+            children: rows,
+        };
+        // Cells are already pipe-table-sanitized by `flatten_for_table_cell`.
+        self.write_table_with(&table, true);
+    }
+
+    /// Pandoc grid table: supports block elements (lists, paragraphs) in cells.
+    fn write_arguments_grid(&mut self, items: &[ArgumentItem]) {
+        use tabled::builder::Builder;
+
+        let mut builder = Builder::default();
+        builder.push_record(["Argument", "Description"]);
+
+        for item in items {
+            let arg_text = crate::format_inline_code(item.name.trim(), false);
+            let desc_text = convert_to_markdown_text(&item.description);
+            builder.push_record([arg_text, desc_text]);
+        }
+
+        let mut table = builder.build();
+        let grid_style = Style::ascii().horizontals([(
+            1,
+            HorizontalLine::new('=')
+                .left('+')
+                .right('+')
+                .intersection('+'),
+        )]);
+        self.write_raw_block(&table.with(grid_style).to_string());
+    }
+
+    /// Quarto list-table: requires Quarto 1.9+, compatible with q2.
+    fn write_arguments_list_table(&mut self, items: &[ArgumentItem]) {
+        let mut output = String::new();
+        output.push_str("::: {.list-table header-rows=1}\n\n");
+        output.push_str("- - Argument\n  - Description\n");
+
+        for item in items {
+            output.push('\n');
+            output.push_str("- - ");
+            output.push_str(&crate::format_inline_code(item.name.trim(), false));
+            output.push('\n');
+            output.push_str("  - ");
+            output.push_str(&render_list_table_cell(&item.description));
+            output.push('\n');
+        }
+
+        output.push_str("\n:::\n");
+        self.write_raw_block(&output);
+    }
+
+    /// Markdown loose list: compatible everywhere.
+    fn write_arguments_list(&mut self, items: &[ArgumentItem]) {
+        let mut output = String::new();
+        for (i, item) in items.iter().enumerate() {
+            if i > 0 {
+                output.push('\n');
+            }
+            output.push_str("- **");
+            output.push_str(&crate::format_inline_code(item.name.trim(), false));
+            output.push_str("**\n");
+
+            let desc = render_block_content(&item.description, 2);
+            if !desc.is_empty() {
+                output.push('\n');
+                output.push_str("  ");
+                output.push_str(&desc);
+                output.push('\n');
+            }
+        }
+        self.write_raw_block(&output);
+    }
+}
+
+/// Replace line endings with a single space, leaving every other byte of
+/// whitespace untouched.
+fn replace_line_endings_with_space(value: &str) -> String {
+    value.replace("\r\n", " ").replace(['\r', '\n'], " ")
+}
+
+/// Convert block nodes to a standalone Markdown string for a grid-table cell.
 ///
 /// Grid tables are built from raw strings by `tabled`, whereas the main mdast
 /// writer owns one global output buffer and tracks whole-document line state.
-/// The dedicated serializers below therefore preserve the legacy subtree path
-/// until the writer can directly serialize isolated AST fragments.
-pub(super) fn convert_to_markdown_text(
-    content: &[RdNode],
-    context: &BlockConversionContext<'_>,
-) -> String {
-    nodes_to_markdown(&convert_block_content(content, context))
+/// The dedicated serializers below therefore keep a separate subtree path
+/// until the writer can directly serialize isolated fragments.
+pub(crate) fn convert_to_markdown_text(nodes: &[Node]) -> String {
+    nodes_to_markdown(nodes)
 }
 
 fn nodes_to_markdown(nodes: &[Node]) -> String {
@@ -100,7 +216,8 @@ fn nodes_to_markdown(nodes: &[Node]) -> String {
             // roxygen code-block path (Code). Keep this arm exhaustive (no
             // wildcard) so a newly added `Node` variant fails to compile here
             // instead of silently vanishing.
-            Node::ThematicBreak
+            Node::Arguments(_)
+            | Node::ThematicBreak
             | Node::Blockquote(_)
             | Node::ListItem(_)
             | Node::TableRow(_)
@@ -127,13 +244,13 @@ fn nodes_to_markdown(nodes: &[Node]) -> String {
     result
 }
 
-pub(super) fn inline_nodes_to_markdown(nodes: &[Node]) -> String {
+pub(crate) fn inline_nodes_to_markdown(nodes: &[Node]) -> String {
     let mut result = String::new();
 
     for node in nodes {
         match node {
             Node::Text(text) => result.push_str(&text.value),
-            Node::InlineCode(code) => result.push_str(&rd2qmd_mdast::format_inline_code(
+            Node::InlineCode(code) => result.push_str(&crate::format_inline_code(
                 &code.value,
                 result.ends_with('`'),
             )),
@@ -151,10 +268,10 @@ pub(super) fn inline_nodes_to_markdown(nodes: &[Node]) -> String {
                 result.push('[');
                 result.push_str(&inline_nodes_to_markdown(&link.children));
                 result.push_str("](");
-                result.push_str(&rd2qmd_mdast::format_link_destination(&link.url));
+                result.push_str(&crate::format_link_destination(&link.url));
                 if let Some(title) = &link.title {
                     result.push_str(" \"");
-                    result.push_str(&rd2qmd_mdast::escape_link_title(title));
+                    result.push_str(&crate::escape_link_title(title));
                     result.push('"');
                 }
                 result.push(')');
@@ -168,10 +285,10 @@ pub(super) fn inline_nodes_to_markdown(nodes: &[Node]) -> String {
                 result.push_str("![");
                 result.push_str(&image.alt);
                 result.push_str("](");
-                result.push_str(&rd2qmd_mdast::format_link_destination(&image.url));
+                result.push_str(&crate::format_link_destination(&image.url));
                 if let Some(title) = &image.title {
                     result.push_str(" \"");
-                    result.push_str(&rd2qmd_mdast::escape_link_title(title));
+                    result.push_str(&crate::escape_link_title(title));
                     result.push('"');
                 }
                 result.push(')');
@@ -198,11 +315,11 @@ fn node_to_text(node: &Node) -> Option<String> {
     }
 }
 
-pub(super) fn render_list_table_cell(nodes: &[Node]) -> String {
+pub(crate) fn render_list_table_cell(nodes: &[Node]) -> String {
     render_block_content(nodes, 4)
 }
 
-pub(super) fn render_block_content(nodes: &[Node], indent: u8) -> String {
+pub(crate) fn render_block_content(nodes: &[Node], indent: u8) -> String {
     let indent = " ".repeat(indent as usize);
     let indent = indent.as_str();
     let mut result = String::new();
@@ -357,13 +474,15 @@ pub(super) fn render_block_content(nodes: &[Node], indent: u8) -> String {
 }
 
 /// Serialize one mdast node through the real writer.
-pub(super) fn node_to_markdown_string(node: &Node) -> String {
+pub(crate) fn node_to_markdown_string(node: &Node) -> String {
     let root = Root::new(vec![node.clone()]);
     let options = WriterOptions {
         frontmatter: None,
         // The migration context has no writer-format option yet. Preserve the
         // legacy call site's default until the document converter is wired.
         quarto_code_blocks: true,
+        // Unreachable from here: an Arguments node never nests inside a cell.
+        arguments_format: ArgumentsFormat::default(),
     };
     mdast_to_qmd(&root, &options).trim().to_owned()
 }

--- a/crates/rd2qmd-mdast/src/writer/block.rs
+++ b/crates/rd2qmd-mdast/src/writer/block.rs
@@ -141,6 +141,10 @@ impl<'a> Writer<'a> {
     }
 
     pub(super) fn write_code(&mut self, c: &crate::mdast::Code) {
+        let is_hidden = c.meta.as_deref() == Some("hidden");
+        if is_hidden && !self.options.quarto_code_blocks {
+            return;
+        }
         self.ensure_newline();
 
         // Determine fence length: must be longer than any backtick sequence in content
@@ -150,7 +154,7 @@ impl<'a> Writer<'a> {
         self.output.push_str(&fence);
         if let Some(lang) = &c.lang {
             // Only use {r} for executable code blocks (Examples section)
-            let is_executable = c.meta.as_deref() == Some("executable");
+            let is_executable = matches!(c.meta.as_deref(), Some("executable" | "hidden"));
             if self.options.quarto_code_blocks && lang == "r" && is_executable {
                 self.output.push_str("{r}");
             } else {
@@ -158,6 +162,9 @@ impl<'a> Writer<'a> {
             }
         }
         self.output.push('\n');
+        if is_hidden {
+            self.output.push_str("#| include: false\n");
+        }
         self.output.push_str(&c.value);
         if !c.value.ends_with('\n') {
             self.output.push('\n');
@@ -168,7 +175,27 @@ impl<'a> Writer<'a> {
     }
 
     pub(super) fn write_table(&mut self, t: &crate::mdast::Table) {
+        self.write_table_with(t, false);
+    }
+
+    /// Write a pipe table, sanitizing cell content for a pipe-table cell
+    /// unless the caller has already done so.
+    ///
+    /// Cells arrive holding unescaped inline content (a `\tabular{}` cell is
+    /// just converted inline nodes), so escaping happens here, at the point
+    /// where the pipe-table syntax is actually chosen. The one exception is
+    /// the Arguments pipe renderer, which must flatten block content down to
+    /// inline nodes first and sanitizes as part of that flattening; escaping
+    /// its cells again would double every backslash.
+    pub(super) fn write_table_with(&mut self, t: &crate::mdast::Table, pre_sanitized: bool) {
         self.ensure_newline();
+        let sanitized;
+        let t = if pre_sanitized {
+            t
+        } else {
+            sanitized = super::table_cell::sanitize_table(t);
+            &sanitized
+        };
 
         let rows: Vec<&crate::mdast::TableRow> = t
             .children

--- a/crates/rd2qmd-mdast/src/writer/mod.rs
+++ b/crates/rd2qmd-mdast/src/writer/mod.rs
@@ -5,10 +5,30 @@
 use crate::mdast::{Node, Root};
 use serde::Serialize;
 
+mod arguments;
 mod block;
 mod inline;
+pub(crate) mod table_cell;
 #[cfg(test)]
 mod tests;
+
+/// Physical rendering chosen for the Arguments section.
+///
+/// This is a presentation decision, so it belongs to the writer rather than
+/// to the Rd -> mdast conversion, which emits a semantic
+/// [`crate::mdast::Arguments`] node.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ArgumentsFormat {
+    /// Pipe table - limited to inline content
+    PipeTable,
+    /// Pandoc grid table - supports block elements in cells
+    GridTable,
+    /// Quarto list-table (default) - requires Quarto 1.9+
+    #[default]
+    ListTable,
+    /// Markdown loose list - compatible everywhere
+    List,
+}
 
 /// Options for the QMD writer
 #[derive(Debug, Clone, Default)]
@@ -17,6 +37,8 @@ pub struct WriterOptions {
     pub frontmatter: Option<Frontmatter>,
     /// Use {r} instead of r for R code blocks
     pub quarto_code_blocks: bool,
+    /// Physical rendering of the Arguments section
+    pub arguments_format: ArgumentsFormat,
 }
 
 /// YAML frontmatter content
@@ -197,6 +219,7 @@ impl<'a> Writer<'a> {
             Node::TableRow(_) => {}  // Handled by write_table
             Node::TableCell(_) => {} // Handled by write_table
             Node::DefinitionList(dl) => self.write_definition_list(dl),
+            Node::Arguments(a) => self.write_arguments(a),
             Node::DefinitionTerm(_) => {} // Handled by write_definition_list
             Node::DefinitionDescription(_) => {} // Handled by write_definition_list
             Node::Text(t) => self.output.push_str(&t.value),
@@ -218,6 +241,17 @@ impl<'a> Writer<'a> {
     }
 
     // Helper methods
+
+    /// Emit an already-rendered Markdown block verbatim.
+    ///
+    /// Used by the Arguments renderers, whose grid-table / list-table / list
+    /// shapes are built as raw strings rather than as mdast subtrees.
+    fn write_raw_block(&mut self, value: &str) {
+        self.output.push_str(value);
+        if !value.is_empty() {
+            self.at_line_start = value.ends_with('\n');
+        }
+    }
 
     fn ensure_newline(&mut self) {
         if !self.at_line_start && !self.output.is_empty() {

--- a/crates/rd2qmd-mdast/src/writer/table_cell.rs
+++ b/crates/rd2qmd-mdast/src/writer/table_cell.rs
@@ -1,19 +1,18 @@
 //! Flattening arbitrary block content down to inline nodes safe for a GFM
 //! pipe-table cell.
 
-use rd_ast::RdNode;
-use rd2qmd_mdast::{Html, Node};
+use crate::mdast::{Html, Node};
 
-use super::markdown_text::node_to_markdown_string;
-use super::{BlockConversionContext, convert_block_content, replace_line_endings_with_space};
+use super::arguments::node_to_markdown_string;
+use super::replace_line_endings_with_space;
 
-/// Flatten block content to inline nodes for GFM table cells.
+/// Flatten block-level nodes to inline nodes for GFM table cells.
 /// Uses `<br>` for paragraph breaks and flattens lists with bullet markers.
-pub(super) fn flatten_for_table_cell(
-    content: &[RdNode],
-    context: &BlockConversionContext<'_>,
-) -> Vec<Node> {
-    let block_nodes = convert_block_content(content, context);
+///
+/// The returned nodes are already sanitized for a pipe-table cell, so they
+/// must be written through the pre-sanitized table path (see
+/// [`super::Writer::write_table_with`]) rather than sanitized a second time.
+pub(crate) fn flatten_for_table_cell(block_nodes: &[Node]) -> Vec<Node> {
     let mut result = Vec::new();
 
     for (i, node) in block_nodes.iter().enumerate() {
@@ -174,7 +173,8 @@ fn flatten_block_node_for_table_cell(node: &Node) -> Vec<Node> {
         // roxygen code-block path (Code). Keep this arm exhaustive (no
         // wildcard) so a newly added `Node` variant fails to compile here
         // instead of silently vanishing.
-        Node::ThematicBreak
+        Node::Arguments(_)
+        | Node::ThematicBreak
         | Node::Blockquote(_)
         | Node::ListItem(_)
         | Node::TableRow(_)
@@ -199,6 +199,34 @@ fn flatten_block_node_for_table_cell(node: &Node) -> Vec<Node> {
     result
 }
 
+/// Sanitize every cell of a table for pipe-table output.
+pub(crate) fn sanitize_table(table: &crate::mdast::Table) -> crate::mdast::Table {
+    let children = table
+        .children
+        .iter()
+        .map(|row| match row {
+            Node::TableRow(row) => {
+                let cells = row
+                    .children
+                    .iter()
+                    .map(|cell| match cell {
+                        Node::TableCell(cell) => {
+                            Node::table_cell(sanitize_table_cell_inline_nodes(&cell.children))
+                        }
+                        other => other.clone(),
+                    })
+                    .collect();
+                Node::table_row(cells)
+            }
+            other => other.clone(),
+        })
+        .collect();
+    crate::mdast::Table {
+        align: table.align.clone(),
+        children,
+    }
+}
+
 fn extend_table_cell_inline(result: &mut Vec<Node>, nodes: &[Node]) {
     result.extend(sanitize_table_cell_inline_nodes(nodes));
 }
@@ -209,7 +237,7 @@ fn extend_table_cell_inline(result: &mut Vec<Node>, nodes: &[Node]) {
 /// conditional branch collapses, see `collapse_inline_nodes`) by splicing
 /// its sanitized children in place, since a `Paragraph` is a block node the
 /// real writer cannot safely nest inside a table cell.
-pub(super) fn sanitize_table_cell_inline_nodes(nodes: &[Node]) -> Vec<Node> {
+pub(crate) fn sanitize_table_cell_inline_nodes(nodes: &[Node]) -> Vec<Node> {
     let mut result = Vec::with_capacity(nodes.len());
     for node in nodes {
         match node {
@@ -222,7 +250,7 @@ pub(super) fn sanitize_table_cell_inline_nodes(nodes: &[Node]) -> Vec<Node> {
     result
 }
 
-pub(super) fn sanitize_table_cell_inline_node(node: &Node) -> Node {
+pub(crate) fn sanitize_table_cell_inline_node(node: &Node) -> Node {
     let mut node = node.clone();
     match &mut node {
         Node::Text(text) => {
@@ -239,7 +267,7 @@ pub(super) fn sanitize_table_cell_inline_node(node: &Node) -> Node {
             math.value = replace_line_endings_with_space(&math.value).replace('|', "\\|");
         }
         Node::Math(math) => {
-            return Node::InlineMath(rd2qmd_mdast::InlineMath {
+            return Node::InlineMath(crate::mdast::InlineMath {
                 value: replace_line_endings_with_space(&math.value).replace('|', "\\|"),
             });
         }

--- a/crates/rd2qmd-mdast/src/writer/tests.rs
+++ b/crates/rd2qmd-mdast/src/writer/tests.rs
@@ -123,6 +123,26 @@ fn test_quarto_code_block() {
 }
 
 #[test]
+fn test_hidden_setup_code_is_only_rendered_for_quarto() {
+    let root = Root::new(vec![Node::code_with_meta(
+        Some("r".to_string()),
+        Some("hidden".to_string()),
+        "setup()",
+    )]);
+    let quarto = mdast_to_qmd(
+        &root,
+        &WriterOptions {
+            quarto_code_blocks: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(quarto, "```{r}\n#| include: false\nsetup()\n```\n");
+
+    let markdown = mdast_to_qmd(&root, &WriterOptions::default());
+    assert!(markdown.is_empty());
+}
+
+#[test]
 fn test_inline_code() {
     let root = Root::new(vec![Node::paragraph(vec![
         Node::text("Use "),
@@ -896,4 +916,125 @@ fn test_frontmatter_with_source_files() {
     assert!(qmd.contains("source-files:\n"));
     assert!(qmd.contains(r#"  - "R/coord-map.R""#));
     assert!(qmd.contains(r#"  - "R/coord-quickmap.R""#));
+}
+
+// ---------------------------------------------------------------------------
+// Pipe-table cell sanitization and grid-table cell rendering
+//
+// These moved here with the Arguments rendering itself: they describe what the
+// Markdown writer does to cell content, not how Rd is parsed.
+// ---------------------------------------------------------------------------
+
+use crate::writer::arguments::convert_to_markdown_text;
+use crate::writer::table_cell::sanitize_table_cell_inline_node;
+
+#[test]
+fn pipe_table_sanitizer_replaces_only_line_endings() {
+    let sanitized = sanitize_table_cell_inline_node(&Node::inline_code("a  b\tc\r\nd\re\n f"));
+    assert!(matches!(
+        sanitized,
+        Node::InlineCode(code) if code.value == "a  b\tc d e  f"
+    ));
+}
+
+#[test]
+fn pipe_table_sanitizer_replaces_inline_code_line_endings() {
+    let sanitized = sanitize_table_cell_inline_node(&Node::inline_code("first\n second"));
+
+    assert!(matches!(sanitized, Node::InlineCode(code) if code.value == "first  second"));
+}
+
+#[test]
+fn pipe_table_sanitizer_escapes_literal_pipes_in_image_urls() {
+    let sanitized = sanitize_table_cell_inline_node(&Node::image("path|name.png", "alt"));
+
+    assert!(
+        matches!(sanitized, Node::Image(image) if image.url == "path\\|name.png" && image.alt == "alt")
+    );
+}
+
+#[test]
+fn pipe_table_sanitizer_replaces_link_title_line_endings() {
+    let sanitized = sanitize_table_cell_inline_node(&Node::link_with_title(
+        "url\nvalue",
+        "title\r\nvalue",
+        vec![Node::text("link")],
+    ));
+    let markdown = mdast_to_qmd(
+        &Root::new(vec![Node::paragraph(vec![sanitized])]),
+        &WriterOptions::default(),
+    );
+
+    assert_eq!(markdown, "[link](<url value> \"title value\")\n");
+}
+
+#[test]
+fn pipe_table_sanitizer_replaces_image_field_line_endings() {
+    let sanitized = sanitize_table_cell_inline_node(&Node::image_with_title(
+        "url\rvalue",
+        "alt\nvalue",
+        "title\r\nvalue",
+    ));
+    let markdown = mdast_to_qmd(
+        &Root::new(vec![Node::paragraph(vec![sanitized])]),
+        &WriterOptions::default(),
+    );
+
+    assert_eq!(markdown, "![alt value](<url value> \"title value\")\n");
+}
+
+#[test]
+fn table_cell_serializer_formats_link_and_image_destinations() {
+    let markdown = crate::writer::arguments::inline_nodes_to_markdown(&[
+        Node::link_with_title(
+            r"link url",
+            r#"link "title" \ docs"#,
+            vec![Node::text(r"link")],
+        ),
+        Node::text(r" "),
+        Node::image_with_title(r"image url", r"alt", r#"image "title" \ docs"#),
+    ]);
+
+    assert_eq!(
+        markdown,
+        r#"[link](<link url> "link \"title\" \\ docs") ![alt](<image url> "image \"title\" \\ docs")"#
+    );
+}
+
+#[test]
+fn grid_table_list_item_second_paragraph_is_indented_under_marker() {
+    // A list item's continuation content must be indented under the marker
+    // column, or a grid-table cell's block-level Markdown parser stops
+    // treating it as part of the same list item.
+    let list = Node::list(
+        false,
+        vec![Node::list_item(vec![
+            Node::paragraph(vec![Node::text("first paragraph")]),
+            Node::paragraph(vec![Node::text("second paragraph")]),
+        ])],
+    );
+
+    assert_eq!(
+        convert_to_markdown_text(&[list]),
+        "- first paragraph\n\n  second paragraph"
+    );
+}
+
+#[test]
+fn grid_table_list_item_cr_break_in_first_paragraph_is_indented_under_marker() {
+    // A hard break *within the first paragraph* of a list item must also be
+    // indented under the marker, not just subsequent sibling blocks.
+    let list = Node::list(
+        false,
+        vec![Node::list_item(vec![Node::paragraph(vec![
+            Node::text("first line"),
+            Node::line_break(),
+            Node::text("second line"),
+        ])])],
+    );
+
+    assert_eq!(
+        convert_to_markdown_text(&[list]),
+        "- first line  \n  second line"
+    );
 }

--- a/crates/rd2qmd-package/src/convert.rs
+++ b/crates/rd2qmd-package/src/convert.rs
@@ -2,8 +2,8 @@
 
 use rayon::prelude::*;
 use rd2qmd_core::{
-    ArgumentsFormat, Frontmatter, RdAstEnvelope, RdToMdastOptions, WriterOptions,
-    extract_rd_metadata, extract_text, mdast_to_qmd, rd_to_mdast_with_options,
+    ArgumentsFormat, CodeExecutionOptions, FrontmatterOptions, LinkOptions, OutputTarget,
+    RdAstEnvelope, RdConvertOptions, convert_rd_document, extract_rd_metadata,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -80,6 +80,8 @@ pub struct PackageConvertOptions {
     /// Prefer the ASCII representation of `\eqn`/`\deqn` equations over
     /// LaTeX math when one is present (default: false)
     pub prefer_ascii_math: bool,
+    /// Markup language to render into (Markdown or Typst)
+    pub target: OutputTarget,
     /// Table format for the Arguments section
     pub arguments_format: ArgumentsFormat,
 }
@@ -102,6 +104,7 @@ impl Default for PackageConvertOptions {
             include_internal: false, // pkgdown-compatible: skip internal topics by default
             include_html_output: false,
             prefer_ascii_math: false,
+            target: OutputTarget::default(),
             arguments_format: ArgumentsFormat::default(),
         }
     }
@@ -371,61 +374,30 @@ pub(crate) fn convert_single_file(
                 .internal_link_url
                 .clone()
                 .unwrap_or_else(|| format!("{{file}}.{}", options.output_extension));
-            let converter_options = RdToMdastOptions {
-                include_title_heading: !options.frontmatter,
-                internal_link_url: Some(internal_link_url),
-                alias_map: Some(package.alias_index.clone()),
-                unqualified_link_url: options.unqualified_link_url.clone(),
-                package_urls: options.package_urls.clone(),
-                external_link_url: options.external_link_url.clone(),
-                exec_dontrun: options.exec_dontrun,
-                exec_donttest: options.exec_donttest,
-                quarto_code_blocks: options.quarto_code_blocks,
-                arguments_format: options.arguments_format.clone(),
+            let convert_options = RdConvertOptions {
+                frontmatter: FrontmatterOptions {
+                    enabled: options.frontmatter,
+                    pagetitle: options.pagetitle,
+                },
+                code: CodeExecutionOptions {
+                    quarto_code_blocks: options.quarto_code_blocks,
+                    exec_dontrun: options.exec_dontrun,
+                    exec_donttest: options.exec_donttest,
+                },
+                links: LinkOptions {
+                    internal_link_url: Some(internal_link_url),
+                    alias_map: Some(package.alias_index.clone()),
+                    unqualified_link_url: options.unqualified_link_url.clone(),
+                    package_urls: options.package_urls.clone(),
+                    external_link_url: options.external_link_url.clone(),
+                },
+                target: options.target,
+                arguments_format: options.arguments_format,
                 include_html_output: options.include_html_output,
                 prefer_ascii_math: options.prefer_ascii_math,
+                source_files_override: Some(source_files),
             };
-
-            // Convert to mdast
-            let mdast = rd_to_mdast_with_options(&doc, &converter_options);
-
-            // Extract title and name for frontmatter
-            let title = doc.title().map(extract_text);
-            let name = doc.name().map(extract_text);
-
-            // Build pagetitle in pkgdown style: "<title> — <name>"
-            let pagetitle = if options.pagetitle {
-                match (&title, &name) {
-                    (Some(t), Some(n)) => Some(format!("{} \u{2014} {}", t, n)),
-                    _ => None,
-                }
-            } else {
-                None
-            };
-
-            // Extract Rd metadata, including source files from roxygen2 comments
-            let metadata = rd2qmd_core::RdMetadata {
-                source_files,
-                ..extract_rd_metadata(&doc)
-            };
-
-            // Build writer options
-            let writer_options = WriterOptions {
-                frontmatter: if options.frontmatter {
-                    Some(Frontmatter {
-                        title,
-                        pagetitle,
-                        format: None,
-                        metadata: Some(metadata),
-                    })
-                } else {
-                    None
-                },
-                quarto_code_blocks: options.quarto_code_blocks,
-            };
-
-            // Convert to QMD string
-            let qmd = mdast_to_qmd(&mdast, &writer_options);
+            let qmd = convert_rd_document(&doc, &convert_options);
 
             // Determine output path
             let relative = input.strip_prefix(&package.root).unwrap_or(input);

--- a/crates/rd2qmd-package/src/tests.rs
+++ b/crates/rd2qmd-package/src/tests.rs
@@ -375,6 +375,7 @@ fn test_package_converter_basic() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -435,6 +436,7 @@ fn test_package_converter_with_alias_resolution() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -482,6 +484,7 @@ x <- 1
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -554,6 +557,7 @@ fn test_package_converter_with_unqualified_link_url() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -594,6 +598,7 @@ fn test_package_converter_with_external_link_url() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -648,6 +653,7 @@ fn test_package_converter_with_package_urls() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -825,6 +831,7 @@ fn test_package_converter_empty_directory() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -864,6 +871,7 @@ fn test_full_convert_result_structure() {
         include_internal: false,
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -921,6 +929,7 @@ fn test_internal_topics_skipped_by_default() {
         include_internal: false, // Default: skip internal
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 
@@ -981,6 +990,7 @@ fn test_internal_topics_included_when_requested() {
         include_internal: true, // Include internal topics
         include_html_output: false,
         prefer_ascii_math: false,
+        target: Default::default(),
         arguments_format: ArgumentsFormat::default(),
     };
 


### PR DESCRIPTION
Hi,

This is a PR illustrating how one could support Typst export in the rd2qmd project. 

WARNING: I gave agents a lot of direction, reviewed spec files carefully, and ran several adversarial reviews with competing frontier agents. But this code is entirely generated, so I'm not sure you'd want to merge this as-is. 

My goal was simply to give us a concrete basis for discussion about whether you'd want to implement this feature in the package, and how you would prefer to go about it.

I had to make a few changes to the core code:

- Represent the Arguments section as a semantic mdast node.
- Move argument formatting and table-cell escaping into the output writers.
- Add the new typ output target to the CLI and configuration machinery.

Aside from that, the implementation is contained in the new crates/rd2qmd-mdast/src/typst/ directory.

I rendered a few man pages in a [Calepin](https://github.com/vincentarelbundock/calepin) website to illustrate the results. It looks pretty good to me! You’ll find some r-polars pages there too, in case you’re curious. For example:

https://vincentarelbundock.github.io/rd2qmd-examples/r-polars/dataframe/dataframe__drop_nulls.html
